### PR TITLE
Fix websocket server startup by installing dotenv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "compression": "^1.7.5",
         "cors": "^2.8.5",
         "date-fns": "^4.1.0",
+        "dotenv": "^16.5.0",
         "express": "^4.21.1",
         "framer-motion": "^11.11.17",
         "helmet": "^8.0.0",
@@ -8107,6 +8108,18 @@
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "compression": "^1.7.5",
     "cors": "^2.8.5",
     "date-fns": "^4.1.0",
+    "dotenv": "^16.5.0",
     "express": "^4.21.1",
     "framer-motion": "^11.11.17",
     "helmet": "^8.0.0",


### PR DESCRIPTION
## Summary
- add missing `dotenv` dependency so websocket-server.js can start without module errors

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f49cef9f0832294c91b667607994c