### PR TITLE
Fix duplicate Chrome note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@
 1. تحقق من سجلات النظام: `npm run logs`
 2. أعد تشغيل النظام: `npm run restart`
 3. تحقق من حالة قاعدة البيانات: `npm run db:check`
-=======
-- **Chromium/Chrome:** لاستخدام WhatsApp Web
 
 ## الإعداد
 


### PR DESCRIPTION
## Summary
- clean up README by removing stray separator and duplicate bullet

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f521dc94c83228c3a9b987e6fba75