### PR TITLE
Fix login token payload and metadata

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -13,7 +13,9 @@ export async function POST(request: NextRequest) {
 
     // التحقق البسيط
     if (username === ADMIN_USERNAME && password === ADMIN_PASSWORD) {
-      const token = jwt.sign({ username }, JWT_SECRET, { expiresIn: "24h" })
+      const token = jwt.sign({ userId: 1, username }, JWT_SECRET, {
+        expiresIn: "24h",
+      })
 
       const response = NextResponse.json({
         success: true,
@@ -115,7 +117,7 @@ export async function POST(request: NextRequest) {
     try {
       token = jwt.sign(
         {
-          id: admin.id,
+          userId: admin.id,
           username: admin.username,
         },
         jwtSecret,

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from "next/og"
 
-export const runtime = "edge"
+export const runtime = "nodejs"
 
 export const size = {
   width: 32,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,11 @@ export const metadata: Metadata = {
   generator: "Next.js",
   keywords: ["WhatsApp", "Manager", "Business", "Communication"],
   authors: [{ name: "WhatsApp Manager Team" }],
-  viewport: "width=device-width, initial-scale=1",
+}
+
+export const viewport = {
+  width: "device-width",
+  initialScale: 1,
 }
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- include `userId` in auth token
- change icon runtime to NodeJS
- move viewport config out of metadata

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f53c0c3948322947c5f9241e9bd3b