### PR TITLE
Centralize JWT config

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -3,9 +3,7 @@ import jwt from "jsonwebtoken"
 import type { NextRequest } from "next/server"
 import { db } from "./database"
 import { logger } from "@/lib/logger"
-
-const JWT_SECRET = process.env.JWT_SECRET || "your-secret-key"
-const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "24h"
+import { JWT_SECRET, JWT_EXPIRES_IN } from "@/lib/config"
 const MAX_LOGIN_ATTEMPTS = Number.parseInt(process.env.MAX_AUTH_ATTEMPTS || "5")
 const LOCK_TIME = 15 * 60 * 1000 // 15 دقيقة
 const ADMIN_USERNAME = process.env.ADMIN_USERNAME || "admin"

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,7 @@
+export const JWT_SECRET = process.env.JWT_SECRET || (process.env.NODE_ENV !== 'production' ? 'your-secret-key' : undefined)
+
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET is not defined in production environment')
+}
+
+export const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '24h'

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -1,9 +1,7 @@
 import type { NextRequest } from "next/server"
 import jwt from "jsonwebtoken"
 import { db } from "./database"
-
-const JWT_SECRET = process.env.JWT_SECRET || "your-secret-key"
-const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "24h"
+import { JWT_SECRET, JWT_EXPIRES_IN } from "@/lib/config"
 
 export async function verifyAuth(request: NextRequest) {
   try {

--- a/websocket-server.js
+++ b/websocket-server.js
@@ -20,7 +20,7 @@ const jwt = require("jsonwebtoken")
 const PORT = process.env.WEBSOCKET_PORT || 3001
 const NODE_ENV = process.env.NODE_ENV || "development"
 const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000"
-const JWT_SECRET = process.env.JWT_SECRET || "your-secret-key"
+const { JWT_SECRET, JWT_EXPIRES_IN } = require("./lib/config")
 
 console.log("🚀 Starting WhatsApp Manager WebSocket Server v5.2.0")
 console.log("🐧 Ubuntu 24.04 LTS Support: ✅")


### PR DESCRIPTION
## Summary
- add `lib/config.ts` to share JWT settings
- use the shared config in auth, middleware and websocket-server

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5a50be4c8322a3e096a3c1ea58cd