### PR TITLE
Explicit database initialization

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -62,11 +62,7 @@ class DatabaseManager {
   private db: Database.Database | null = null
   private initialized = false
 
-  constructor() {
-    this.init().catch((err) => {
-      logger.error("Failed to initialize database:", err)
-    })
-  }
+  constructor() {}
 
   async init(): Promise<Database.Database | null> {
     try {
@@ -537,6 +533,11 @@ class DatabaseManager {
 
 // إنشاء instance واحد من DatabaseManager
 export const db = new DatabaseManager()
+
+// Explicit initialization function
+export async function initializeDatabase() {
+  return db.init()
+}
 
 // تصدير الأنواع
 export type { Admin, Device, Message, IncomingMessage }

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const next = require("next")
 const helmet = require("helmet")
 const compression = require("compression")
 const rateLimit = require("express-rate-limit")
+const { initializeDatabase } = require("./lib/database")
 
 const dev = process.env.NODE_ENV !== "production"
 const hostname = process.env.HOST || "127.0.0.1"
@@ -29,6 +30,9 @@ const handle = app.getRequestHandler()
 // دالة لبدء الخادم
 async function startServer() {
   try {
+    console.log("🔄 Initializing database...")
+    await initializeDatabase()
+    console.log("✅ Database initialized")
     console.log("🔄 Preparing Next.js application...")
     await app.prepare()
     console.log("✅ Next.js application prepared successfully")

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -39,7 +39,7 @@ beforeAll(async () => {
   process.env.ADMIN_USERNAME = `test_admin_${Date.now()}`;
   const dbModule = await import('../lib/database');
   db = dbModule.db;
-  await new Promise((r) => setTimeout(r, 50));
+  await dbModule.initializeDatabase();
 
   const managerModule = await import('../lib/whatsapp-client-manager');
   whatsappManagerMock = managerModule.whatsappManager;

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -7,7 +7,7 @@ beforeAll(async () => {
   process.env.ADMIN_USERNAME = `test_admin_${Date.now()}`;
   const dbModule = await import('../lib/database');
   db = dbModule.db;
-  await new Promise((r) => setTimeout(r, 50));
+  await dbModule.initializeDatabase();
 });
 
 afterAll(() => {


### PR DESCRIPTION
## Summary
- create explicit `initializeDatabase` helper
- initialize database before starting server
- update tests to initialize the database directly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f59bfc98483228ed58eec5e1ef2e8