### PR TITLE
Fix verifyAuth import

### DIFF
--- a/app/api/stats/system/route.ts
+++ b/app/api/stats/system/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth } from "@/lib/middleware"
 import os from "os"
 import fs from "fs"
 


### PR DESCRIPTION
## Summary
- correct the verifyAuth import path in system stats route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f59bbfa288322840f319b383c8be4