### PR TITLE
Fix websocket config require

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,9 @@
+const JWT_SECRET = process.env.JWT_SECRET || (process.env.NODE_ENV !== 'production' ? 'your-secret-key' : undefined)
+
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET is not defined in production environment')
+}
+
+const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '24h'
+
+module.exports = { JWT_SECRET, JWT_EXPIRES_IN }


### PR DESCRIPTION
## Summary
- add `lib/config.js` so `websocket-server.js` can load configuration in Node.js

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe3a626c48322aba3ecea7b6340fa