### PR TITLE
Add contacts table and routes

### DIFF
--- a/app/api/contacts/[id]/route.ts
+++ b/app/api/contacts/[id]/route.ts
@@ -1,0 +1,81 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { db } from "@/lib/database"
+import { verifyAuth } from "@/lib/middleware"
+import { ValidationSchemas } from "@/lib/validation"
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const authResult = await verifyAuth(request)
+    if (!authResult.success) {
+      return NextResponse.json(authResult, { status: 401 })
+    }
+
+    const contactId = Number.parseInt(params.id)
+    if (isNaN(contactId)) {
+      return NextResponse.json({ success: false, error: "معرف غير صالح", timestamp: new Date().toISOString() }, { status: 400 })
+    }
+
+    const contact = await db.getContact(contactId)
+    if (!contact) {
+      return NextResponse.json({ success: false, error: "جهة الاتصال غير موجودة", timestamp: new Date().toISOString() }, { status: 404 })
+    }
+
+    return NextResponse.json({ success: true, contact, timestamp: new Date().toISOString() })
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, error: "خطأ في جلب جهة الاتصال", details: error instanceof Error ? error.message : "Unknown error", timestamp: new Date().toISOString() },
+      { status: 500 },
+    )
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const authResult = await verifyAuth(request)
+    if (!authResult.success) {
+      return NextResponse.json(authResult, { status: 401 })
+    }
+
+    const contactId = Number.parseInt(params.id)
+    if (isNaN(contactId)) {
+      return NextResponse.json({ success: false, error: "معرف غير صالح", timestamp: new Date().toISOString() }, { status: 400 })
+    }
+
+    const body = await request.json()
+    const contactData = ValidationSchemas.contact(body)
+    if (!contactData) {
+      return NextResponse.json({ success: false, error: "بيانات جهة الاتصال غير صحيحة", timestamp: new Date().toISOString() }, { status: 400 })
+    }
+
+    await db.updateContact(contactId, contactData)
+    const updated = await db.getContact(contactId)
+    return NextResponse.json({ success: true, contact: updated, timestamp: new Date().toISOString() })
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, error: "خطأ في تحديث جهة الاتصال", details: error instanceof Error ? error.message : "Unknown error", timestamp: new Date().toISOString() },
+      { status: 500 },
+    )
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const authResult = await verifyAuth(request)
+    if (!authResult.success) {
+      return NextResponse.json(authResult, { status: 401 })
+    }
+
+    const contactId = Number.parseInt(params.id)
+    if (isNaN(contactId)) {
+      return NextResponse.json({ success: false, error: "معرف غير صالح", timestamp: new Date().toISOString() }, { status: 400 })
+    }
+
+    await db.deleteContact(contactId)
+    return NextResponse.json({ success: true, message: "تم حذف جهة الاتصال", timestamp: new Date().toISOString() })
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, error: "خطأ في حذف جهة الاتصال", details: error instanceof Error ? error.message : "Unknown error", timestamp: new Date().toISOString() },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/contacts/route.ts
+++ b/app/api/contacts/route.ts
@@ -1,0 +1,73 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { db } from "@/lib/database"
+import { verifyAuth } from "@/lib/middleware"
+import { ValidationSchemas } from "@/lib/validation"
+
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await verifyAuth(request)
+    if (!authResult.success) {
+      return NextResponse.json(authResult, { status: 401 })
+    }
+
+    const contacts = await db.listContacts()
+    return NextResponse.json({
+      success: true,
+      contacts,
+      count: contacts.length,
+      timestamp: new Date().toISOString(),
+    })
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "خطأ في جلب جهات الاتصال",
+        details: error instanceof Error ? error.message : "Unknown error",
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const authResult = await verifyAuth(request)
+    if (!authResult.success) {
+      return NextResponse.json(authResult, { status: 401 })
+    }
+
+    const body = await request.json()
+    const contactData = ValidationSchemas.contact(body)
+    if (!contactData) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "بيانات جهة الاتصال غير صحيحة",
+          timestamp: new Date().toISOString(),
+        },
+        { status: 400 },
+      )
+    }
+
+    const contact = await db.createContact(contactData.name, contactData.phoneNumber)
+    return NextResponse.json(
+      {
+        success: true,
+        contact,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 201 },
+    )
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "خطأ في إنشاء جهة الاتصال",
+        details: error instanceof Error ? error.message : "Unknown error",
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    )
+  }
+}

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -20,6 +20,11 @@ export const SendBulkMessageSchema = z.object({
   message: z.string().min(1, "نص الرسالة مطلوب").max(1000, "الرسالة طويلة جداً"),
 })
 
+export const ContactSchema = z.object({
+  name: z.string().min(1, "اسم جهة الاتصال مطلوب"),
+  phoneNumber: z.string().min(1, "رقم الهاتف مطلوب"),
+})
+
 // تصدير إضافي للتوافق مع الكود القديم
 export const loginSchema = LoginSchema
 
@@ -48,6 +53,15 @@ export const ValidationSchemas = {
       return SendBulkMessageSchema.parse(data)
     } catch (error) {
       console.error("Bulk message validation error:", error)
+      return null
+    }
+  },
+
+  contact: (data: any) => {
+    try {
+      return ContactSchema.parse(data)
+    } catch (error) {
+      console.error("Contact validation error:", error)
       return null
     }
   },

--- a/scripts/init-database.js
+++ b/scripts/init-database.js
@@ -53,6 +53,17 @@ async function initDatabase() {
           )
         `)
 
+        // إنشاء جدول جهات الاتصال
+        db.run(`
+          CREATE TABLE IF NOT EXISTS contacts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            phone_number TEXT UNIQUE NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+          )
+        `)
+
         // إنشاء جدول الرسائل
         db.run(`
           CREATE TABLE IF NOT EXISTS messages (

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -13,6 +13,7 @@ jest.mock('@/lib/validation', () => ({
   ValidationSchemas: {
     createDevice: jest.fn().mockReturnValue({ name: 'API Device' }),
     createMessage: jest.fn().mockReturnValue({ recipient: '123456789', message: 'hi', deviceId: 1 }),
+    contact: jest.fn().mockReturnValue({ name: 'Test Contact', phoneNumber: '12345' }),
   },
 }));
 
@@ -32,6 +33,7 @@ jest.mock('@/lib/whatsapp-client-manager', () => {
 let db: any;
 let createDevicePost: any;
 let sendMessagePost: any;
+let createContactPost: any;
 let whatsappManagerMock: any;
 
 beforeAll(async () => {
@@ -46,6 +48,7 @@ beforeAll(async () => {
 
   createDevicePost = (await import('../app/api/devices/route')).POST;
   sendMessagePost = (await import('../app/api/devices/[id]/send/route')).POST;
+  createContactPost = (await import('../app/api/contacts/route')).POST;
 });
 
 afterAll(() => {
@@ -80,4 +83,18 @@ test('POST /api/devices/[id]/send sends a message', async () => {
   expect(res.status).toBe(200);
   expect(data.success).toBe(true);
   expect(whatsappManagerMock.sendMessage).toHaveBeenCalled();
+});
+
+test('POST /api/contacts creates a contact', async () => {
+  const req: any = {
+    json: async () => ({ name: 'Test Contact', phoneNumber: '12345' }),
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    cookies: { get: () => undefined },
+  };
+
+  const res = await createContactPost(req);
+  const data = await res.json();
+  expect(res.status).toBe(201);
+  expect(data.success).toBe(true);
+  expect(data.contact).toBeDefined();
 });

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -34,3 +34,10 @@ test('createMessage inserts a new message', async () => {
   expect(message.deviceId).toBe(device.id);
   expect(message.message).toBe('Hello');
 });
+
+test('createContact inserts a new contact', async () => {
+  const contact = await db.createContact('Tester', '12345');
+  expect(contact).toBeDefined();
+  expect(contact.name).toBe('Tester');
+  expect(contact.phoneNumber).toBe('12345');
+});


### PR DESCRIPTION
## Summary
- create `contacts` table setup in database
- add CRUD helpers for contacts
- add validation for contacts
- create contacts API routes
- test database and API contact logic

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_68401ec803988322a6e2c33de1e229dd