### PR TITLE
Add strict mode to shell scripts

### DIFF
--- a/docker-commands.sh
+++ b/docker-commands.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # أوامر إدارة Docker للنظام
 

--- a/install-docker.sh
+++ b/install-docker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 echo "🐳 تثبيت Docker و Docker Compose..."
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # ألوان
 RED='\033[0;31m'

--- a/logs.sh
+++ b/logs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 echo "📋 عرض سجلات WhatsApp Manager..."
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # سكريبت تشغيل WhatsApp Manager
 

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # سكريبت إيقاف WhatsApp Manager
 

--- a/start-production.sh
+++ b/start-production.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 echo "🚀 بدء تشغيل WhatsApp Manager في وضع الإنتاج..."
 

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 echo "🚀 تشغيل WhatsApp Manager..."
 

--- a/status.sh
+++ b/status.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 echo "📊 حالة WhatsApp Manager..."
 

--- a/stop.sh
+++ b/stop.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 echo "🛑 إيقاف WhatsApp Manager..."
 

--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # WhatsApp Manager CLI
 # إصدار: 1.0.0


### PR DESCRIPTION
## Summary
- enforce strict mode in bash scripts via `set -euo pipefail`

## Testing
- `bash start.sh` *(fails: Docker Compose not installed)*
- `bash stop.sh` *(fails: docker-compose command not found)*
- `bash logs.sh` *(fails: docker-compose command not found)*
- `bash status.sh` *(fails: docker-compose command not found)*
- `bash wa-manager.sh start` *(fails: docker-compose command not found)*
- `bash install-docker.sh` *(fails: apt-get could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_684403894440832292c3bc280904f297