### PR TITLE
Update script path handling

### DIFF
--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -15,8 +15,10 @@ NC='\033[0m' # No Color
 
 # المسار الافتراضي
 DEFAULT_PATH="/opt/whatsapp-manager"
+# مسار السكريبت
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # المسار الحالي
-CURRENT_PATH=$(pwd)
+CURRENT_PATH="$SCRIPT_DIR"
 
 # التحقق من وجود الملفات المطلوبة
 check_files() {
@@ -146,7 +148,7 @@ install_full() {
     mkdir -p $DEFAULT_PATH/ssl
     
     # نسخ الملفات
-    cp -r $CURRENT_PATH/* $DEFAULT_PATH/
+    cp -r "$SCRIPT_DIR"/* "$DEFAULT_PATH/"
     
     # إنشاء ملف .env
     cat > $DEFAULT_PATH/.env << EOL


### PR DESCRIPTION
## Summary
- set SCRIPT_DIR at top of `wa-manager.sh`
- copy install files from SCRIPT_DIR

## Testing
- `npx jest --runInBand` *(fails: canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68440364f2788322bf8ea713c20b9bc4