### PR TITLE
Fix incomplete tests

### DIFF
--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -97,6 +97,7 @@ test('GET /api/analytics returns summary', async () => {
   expect(res.status).toBe(200);
   expect(data.success).toBe(true);
   expect(Array.isArray(data.summary)).toBe(true);
+});
 
 
 test('POST /api/contacts creates a contact', async () => {

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -43,6 +43,7 @@ test('createAnalyticsEvent stores event and summary returns counts', async () =>
   const summary = await db.getAnalyticsSummary();
   const row = summary.find((s: any) => s.eventType === 'test_event');
   expect(row?.count).toBeGreaterThanOrEqual(1);
+});
 
 test('createContact inserts a new contact', async () => {
   const contact = await db.createContact('Tester', '12345');


### PR DESCRIPTION
## Summary
- close `createAnalyticsEvent` test in database.test
- close `GET /api/analytics` test in api.test

## Testing
- `npx tsc tests/database.test.ts tests/api.test.ts --noEmit --skipLibCheck` *(fails: Cannot find Promise and other types)*

------
https://chatgpt.com/codex/tasks/task_e_684409ab6fa48322be85ffa23a9782c7