### PR TITLE
Add ensureInitialized method to DatabaseManager

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -74,6 +74,12 @@ class DatabaseManager {
     this.init()
   }
 
+  public async ensureInitialized(): Promise<void> {
+    if (!this.initialized) {
+      this.init()
+    }
+  }
+
   private init(): void {
     try {
       // التأكد من وجود مجلد البيانات
@@ -611,6 +617,7 @@ class DatabaseManager {
 export const db = new DatabaseManager()
 
 // Explicit initialization function
-export function initializeDatabase() {
+export async function initializeDatabase() {
+  await db.ensureInitialized()
   return db
 }


### PR DESCRIPTION
## Summary
- add `ensureInitialized` to DatabaseManager
- call it in `initializeDatabase`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684409a2089c83228902f9bcee36be23