### PR TITLE
Fix data/logs permissions in installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ HTTP_PORT=8080 HTTPS_PORT=8443 docker-compose up -d
 The application will then be served through Nginx on `http://localhost:8080` (or
 `https://localhost:8443` when HTTPS is configured).
 Make sure the `data` and `logs` directories on the host are writable by UID 1001
-(the user inside the container). Without the correct permissions the container
-will fail with an “attempt to write a readonly database” error.
-You can adjust the ownership with:
+(the user inside the container). Starting with the included installer this
+ownership is adjusted automatically, but if you run the containers manually
+you can fix the permissions with:
 
 ```bash
 sudo chown -R 1001:1001 data logs

--- a/start-production.sh
+++ b/start-production.sh
@@ -4,6 +4,8 @@ echo "🚀 بدء تشغيل WhatsApp Manager في وضع الإنتاج..."
 
 # التأكد من وجود المجلدات الضرورية
 mkdir -p logs data backups
+# Ensure proper ownership so the container can write to the database and logs
+chown -R 1001:1001 data logs
 
 # إنشاء قاعدة البيانات إذا لم تكن موجودة
 if [ ! -f "data/whatsapp_manager.db" ]; then

--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -157,6 +157,8 @@ install_full() {
     mkdir -p $DEFAULT_PATH
     mkdir -p $DEFAULT_PATH/data
     mkdir -p $DEFAULT_PATH/logs
+    # Ensure correct permissions for database and log directories
+    chown -R 1001:1001 $DEFAULT_PATH/data $DEFAULT_PATH/logs
     mkdir -p $DEFAULT_PATH/ssl
     
     # نسخ الملفات
@@ -432,6 +434,8 @@ start_system() {
     
     # إنشاء المجلدات
     mkdir -p data logs
+    # ضبط الصلاحيات للسماح للحاوية بالكتابة على الملفات
+    chown -R 1001:1001 data logs
     
     # تشغيل Docker Compose
     docker-compose up -d


### PR DESCRIPTION
## Summary
- adjust ownership automatically when installing to avoid readonly DB
- ensure start script grants correct permissions
- mention installer handles permissions in docs

## Testing
- `npm install` *(fails: 7 vulnerabilities)*
- `npx jest` *(failed: canceled asking for install)*

------
https://chatgpt.com/codex/tasks/task_e_68440e7b31f883229dd63a665fb7fd51