### PR TITLE
Add catch for JWT sign errors

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -140,6 +140,9 @@ export async function POST(request: NextRequest) {
         JWT_SECRET,
         { expiresIn: JWT_EXPIRES_IN },
       )
+    } catch (error) {
+      logger.error("JWT sign error:", error)
+      throw error
     }
 
     logger.info("Login successful", { username })


### PR DESCRIPTION
## Summary
- add error handling for JWT signing in login route

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844214b3cd8832299792ac0c133c6a3