### PR TITLE
Improve install_full error handling

### DIFF
--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -20,6 +20,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # المسار الحالي
 CURRENT_PATH="$SCRIPT_DIR"
 
+# Exit immediately if a command exits with a non-zero status
+set -e
+
 # التحقق من تشغيل السكريبت بصلاحيات الجذر
 require_root() {
     if [[ $EUID -ne 0 ]]; then
@@ -383,12 +386,16 @@ EOL
     
     # تشغيل النظام
     cd $DEFAULT_PATH
-    docker-compose up -d
-    
-    echo -e "${GREEN}✅ تم تثبيت WhatsApp Manager بنجاح!${NC}"
-    echo -e "${BLUE}🌐 يمكنك الوصول للنظام عبر: https://${DOMAIN_NAME}${NC}"
-    echo -e "${YELLOW}👤 المستخدم: admin${NC}"
-    echo -e "${YELLOW}🔑 كلمة المرور: admin123${NC}"
+
+    if docker-compose up -d; then
+        echo -e "${GREEN}✅ تم تثبيت WhatsApp Manager بنجاح!${NC}"
+        echo -e "${BLUE}🌐 يمكنك الوصول للنظام عبر: https://${DOMAIN_NAME}${NC}"
+        echo -e "${YELLOW}👤 المستخدم: admin${NC}"
+        echo -e "${YELLOW}🔑 كلمة المرور: admin123${NC}"
+    else
+        echo -e "${RED}❌ فشل تشغيل الحاويات عبر Docker Compose${NC}"
+        exit 1
+    fi
 }
 
 # تثبيت الأمر في النظام


### PR DESCRIPTION
## Summary
- exit on first failure with `set -e`
- check docker-compose result in `install_full`

## Testing
- `npm ci --ignore-scripts`
- `npx jest` *(fails: need to install jest)*
- `npm run lint` *(fails: interactive prompt)*
- `bash wa-manager.sh install full` with fake commands to force docker-compose failure

------
https://chatgpt.com/codex/tasks/task_e_6844214c7b208322afe81a4183d7b6ae