### PR TITLE
Refactor auth verification imports

### DIFF
--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/middleware"
+import { verifyAuth } from "@/lib/auth"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"

--- a/app/api/contacts/[id]/route.ts
+++ b/app/api/contacts/[id]/route.ts
@@ -3,7 +3,7 @@ export const dynamic = "force-dynamic"
 
 import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/middleware"
+import { verifyAuth } from "@/lib/auth"
 import { ValidationSchemas } from "@/lib/validation"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {

--- a/app/api/contacts/route.ts
+++ b/app/api/contacts/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/middleware"
+import { verifyAuth } from "@/lib/auth"
 import { ValidationSchemas } from "@/lib/validation"
 
 export const runtime = "nodejs"

--- a/app/api/devices/[id]/connect/route.ts
+++ b/app/api/devices/[id]/connect/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/middleware"
+import { verifyAuth } from "@/lib/auth"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"

--- a/app/api/devices/[id]/disconnect/route.ts
+++ b/app/api/devices/[id]/disconnect/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/middleware"
+import { verifyAuth } from "@/lib/auth"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"

--- a/app/api/devices/[id]/route.ts
+++ b/app/api/devices/[id]/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/middleware"
+import { verifyAuth } from "@/lib/auth"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 
 export const runtime = "nodejs"

--- a/app/api/devices/[id]/send-bulk/route.ts
+++ b/app/api/devices/[id]/send-bulk/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/middleware"
+import { verifyAuth } from "@/lib/auth"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"

--- a/app/api/devices/[id]/send/route.ts
+++ b/app/api/devices/[id]/send/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/middleware"
+import { verifyAuth } from "@/lib/auth"
 import { ValidationSchemas } from "@/lib/validation"
 
 export const runtime = "nodejs"

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { verifyAuth } from "@/lib/middleware"
+import { verifyAuth } from "@/lib/auth"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -4,54 +4,16 @@ export const dynamic = "force-dynamic"
 import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
 import { logger } from "@/lib/logger"
-import jwt from "jsonwebtoken"
-
-const JWT_SECRET = process.env.JWT_SECRET || "fallback-secret-key"
-
-async function verifyAuth(request: NextRequest) {
-  try {
-    // محاولة قراءة التوكن من الكوكيز أولاً
-    let token = request.cookies.get("auth-token")?.value
-
-    // إذا لم يوجد في الكوكيز، جرب Authorization header
-    if (!token) {
-      const authHeader = request.headers.get("authorization")
-      if (authHeader && authHeader.startsWith("Bearer ")) {
-        token = authHeader.split(" ")[1]
-      }
-    }
-
-    if (!token) {
-      logger.warn("No token found in cookies or headers")
-      return { user: null, error: "No token provided" }
-    }
-
-    logger.info("Token found, verifying...")
-
-    // التحقق من صحة التوكن
-    const decoded = jwt.verify(token, JWT_SECRET) as any
-
-    if (!decoded || !decoded.userId) {
-      logger.warn("Invalid token structure:", decoded)
-      return { user: null, error: "Invalid token" }
-    }
-
-    logger.info("Token verified successfully for user:", decoded.userId)
-    return { user: decoded, error: null }
-  } catch (error) {
-    logger.error("Auth verification failed:", error)
-    return { user: null, error: "Authentication failed" }
-  }
-}
+import { verifyAuth } from "@/lib/auth"
 
 export async function GET(request: NextRequest) {
   try {
     logger.info("🔍 GET /api/stats - Starting request")
 
     // التحقق من المصادقة
-    const { user, error } = await verifyAuth(request)
-    if (!user) {
-      logger.warn("❌ Authentication failed:", error)
+    const authResult = await verifyAuth(request)
+    if (!authResult.success || !authResult.user) {
+      logger.warn("❌ Authentication failed:", authResult.message)
       return NextResponse.json({ success: false, error: "غير مصرح" }, { status: 401 })
     }
 

--- a/app/api/stats/system/route.ts
+++ b/app/api/stats/system/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { verifyAuth } from "@/lib/middleware"
+import { verifyAuth } from "@/lib/auth"
 import os from "os"
 import fs from "fs"
 

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/middleware"
+import { verifyAuth } from "@/lib/auth"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -17,9 +17,6 @@ jest.mock('@/lib/validation', () => ({
   },
 }));
 
-jest.mock('@/lib/middleware', () => ({
-  verifyAuth: jest.fn().mockResolvedValue({ success: true, user: { id: 1, username: 'test' } })
-}));
 
 jest.mock('@/lib/auth', () => ({
   verifyAuth: jest.fn().mockResolvedValue({ success: true, user: { id: 1, username: 'test' } })


### PR DESCRIPTION
## Summary
- centralize verifyAuth usage across API routes
- remove custom auth function from stats endpoint
- adjust tests to mock shared auth verifier

## Testing
- `CI=true npx jest` *(fails: jest-environment-jsdom missing build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68445f4402148322bbb19a54367e957a