### PR TITLE
Add npm test script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,9 @@ npm run type-check
 
 # بناء المشروع
 npm run build
+
+# تشغيل الاختبارات
+npm test
 \`\`\`
 
 ### 5. Commit التغييرات

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ For production with SSL certificates run `wa-manager install full` and follow th
 
 ## Running tests
 
-Install dependencies and execute Jest:
+Install dependencies and run the test suite:
 
 ```bash
 npm install
-npx jest
+npm test
 ```
 
 ## Generating SSL certificates

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "production": "npm run build && npm start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.0.5",


### PR DESCRIPTION
## Summary
- enable `npm test` by defining a Jest script
- clarify how to run tests in README
- document testing step in CONTRIBUTING guide

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445f4518888322b122a0e5d56601a9