### PR TITLE
Disable login test component in production

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -59,3 +59,9 @@ export ADMIN_PASSWORD=supersecret
 ## URL:
 http://localhost:3000 or http://localhost:3001
 The server listens on `0.0.0.0` by default. Set the `HOST` environment variable to change this.
+
+### Development login test
+
+For local debugging you can use the `components/login-test.tsx` component to
+verify authentication. It renders nothing when `NODE_ENV` is `production`, so it
+should not be included in production builds.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ npm install
 npm test
 ```
 
+## Development login test
+
+The repository includes a small component `components/login-test.tsx` for
+verifying the authentication flow during development. It automatically returns
+`null` when `NODE_ENV` is `production` so it won't appear in the production UI.
+Import and use this component only when debugging login issues locally.
+
 ## Generating SSL certificates
 
 Use Certbot to create the TLS certificate files expected by the Nginx configuration:

--- a/components/login-test.tsx
+++ b/components/login-test.tsx
@@ -9,7 +9,13 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { CheckCircle, XCircle, Loader2, Eye, EyeOff } from "lucide-react"
 
+// This component is only meant for development testing of the login API.
+// When NODE_ENV is set to "production" it will render nothing so it isn't
+// included in the UI.
 export default function LoginTest() {
+  if (process.env.NODE_ENV === "production") {
+    return null
+  }
   const [credentials, setCredentials] = useState({
     username: "admin",
     password: "admin123!@#",


### PR DESCRIPTION
## Summary
- hide `login-test` component when NODE_ENV is production
- document development-only login test in README and QUICK_START

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684552c40c04832291f1f76d2c6af413