### PR TITLE
Update CORS defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,8 @@ ADMIN_PASSWORD=admin123
 # Server settings
 PORT=3000
 HOST=0.0.0.0
-CORS_ORIGIN=*
+# Comma-separated list of allowed origins. Leave blank to restrict to same origin.
+CORS_ORIGIN=
 RATE_LIMIT_MAX_REQUESTS=100
 
 # Database

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Create a `.env` file and provide the required variables:
 
 Additional options such as `PORT`, `HOST`, and WebSocket settings can also be set.
 
+To allow cross-origin requests, set `CORS_ORIGIN` to a comma-separated list of allowed origins (e.g. `https://example.com,http://localhost:3000`).
+If left unset, only same-origin requests are permitted.
+
 ## CLI installation
 
 The repository includes a helper CLI called `wa-manager`.

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -13,7 +13,7 @@ export const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || "admin123"
 // إعدادات الخادم
 export const PORT = Number.parseInt(process.env.PORT || "3000")
 export const HOST = process.env.HOST || "0.0.0.0"
-export const CORS_ORIGIN = process.env.CORS_ORIGIN || "*"
+export const CORS_ORIGIN = process.env.CORS_ORIGIN
 export const RATE_LIMIT_MAX_REQUESTS = Number.parseInt(process.env.RATE_LIMIT_MAX_REQUESTS || "100")
 
 // إعدادات قاعدة البيانات

--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ const fs = require("fs")
 const cors = require("cors")
 const compression = require("compression")
 const helmet = require("helmet")
+const { CORS_ORIGIN } = require("./lib/config")
 
 // تهيئة المتغيرات
 const dev = process.env.NODE_ENV !== "production"
@@ -51,7 +52,7 @@ app.prepare().then(() => {
   server.use(compression())
   server.use(
     cors({
-      origin: process.env.CORS_ORIGIN || "*",
+      origin: CORS_ORIGIN ? CORS_ORIGIN.split(',') : false,
       methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
       allowedHeaders: ["Content-Type", "Authorization"],
     }),


### PR DESCRIPTION
## Summary
- set `CORS_ORIGIN` to undefined by default
- use same-origin requests when `CORS_ORIGIN` is unset
- document how to configure CORS

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684552c28c548322a57444a32ac2ad43