### PR TITLE
Centralize JWT secret

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -6,9 +6,8 @@ import bcrypt from "bcryptjs"
 import jwt from "jsonwebtoken"
 import { db } from "@/lib/database"
 import { logger } from "@/lib/logger"
+import { JWT_SECRET } from "@/lib/config"
 
-// استخدام نفس JWT_SECRET في جميع الملفات
-const JWT_SECRET = process.env.JWT_SECRET || "fallback-secret-key"
 const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "24h"
 const ADMIN_USERNAME = process.env.ADMIN_USERNAME || "admin"
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || "admin123"

--- a/lib/auth-helper.ts
+++ b/lib/auth-helper.ts
@@ -1,8 +1,7 @@
 import type { NextRequest } from "next/server"
 import { logger } from "./logger"
 import jwt from "jsonwebtoken"
-
-const JWT_SECRET = process.env.JWT_SECRET || "fallback-secret-key"
+import { JWT_SECRET } from "./config"
 
 export async function verifyAuth(request: NextRequest) {
   try {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -3,8 +3,8 @@ import jwt from "jsonwebtoken"
 import bcrypt from "bcryptjs"
 import { logger } from "./logger"
 import { db } from "./database"
+import { JWT_SECRET } from "./config"
 
-const JWT_SECRET = process.env.JWT_SECRET || "fallback-secret-key"
 const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "24h"
 const REFRESH_TOKEN_EXPIRES_IN = process.env.REFRESH_TOKEN_EXPIRES_IN || "7d"
 

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -1,8 +1,7 @@
 import type { NextRequest } from "next/server"
 import jwt from "jsonwebtoken"
 import { logger } from "./logger"
-
-const JWT_SECRET = process.env.JWT_SECRET || "fallback-secret-key"
+import { JWT_SECRET } from "./config"
 
 interface AuthResult {
   success: boolean

--- a/lib/websocket-server-fixed.ts
+++ b/lib/websocket-server-fixed.ts
@@ -1,10 +1,10 @@
 import { logger } from "./logger"
+import { JWT_SECRET } from "./config"
 
 // إعدادات البيئة
 const PORT = process.env.WEBSOCKET_PORT || 3001
 const NODE_ENV = process.env.NODE_ENV || "development"
 const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000"
-const JWT_SECRET = process.env.JWT_SECRET || "fallback-secret-key"
 
 interface WebSocketServerInstance {
   server: any

--- a/lib/websocket-server.ts
+++ b/lib/websocket-server.ts
@@ -6,12 +6,12 @@ import helmet from "helmet"
 import compression from "compression"
 import jwt from "jsonwebtoken"
 import { logger } from "./logger"
+import { JWT_SECRET } from "./config"
 
 // إعدادات البيئة
 const PORT = process.env.WEBSOCKET_PORT || 3001
 const NODE_ENV = process.env.NODE_ENV || "development"
 const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000"
-const JWT_SECRET = process.env.JWT_SECRET || "fallback-secret-key"
 
 interface WebSocketServerInstance {
   server: any

--- a/lib/websocket.ts
+++ b/lib/websocket.ts
@@ -2,6 +2,7 @@ import { createServer } from "http"
 import { Server } from "socket.io"
 import jwt from "jsonwebtoken"
 import * as logger from "./logger"
+import { JWT_SECRET } from "./config"
 
 interface WebSocketServerInstance {
   io: Server | null
@@ -44,7 +45,7 @@ export function initializeWebSocketServer(port = 3001): WebSocketServerInstance 
       }
 
       try {
-        const decoded = jwt.verify(token, process.env.JWT_SECRET || "fallback-secret")
+        const decoded = jwt.verify(token, JWT_SECRET)
         socket.user = decoded
         logger.info(`✅ Authenticated socket user: ${(decoded as any).username}`)
       } catch (error) {

--- a/websocket-server.js
+++ b/websocket-server.js
@@ -20,26 +20,11 @@ const jwt = require("jsonwebtoken")
 const PORT = process.env.WEBSOCKET_PORT || 3001
 const NODE_ENV = process.env.NODE_ENV || "development"
 const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000"
-// Load configuration explicitly using __dirname to avoid path issues
-const path = require("path")
 
-// Load configuration with proper error handling
 let JWT_SECRET, JWT_EXPIRES_IN
-
 try {
-  // Try to load from lib/config.js first
-  const configPath = path.join(__dirname, "lib", "config.js")
-  if (require("fs").existsSync(configPath)) {
-    const config = require(configPath)
-    JWT_SECRET = config.JWT_SECRET
-    JWT_EXPIRES_IN = config.JWT_EXPIRES_IN
-  } else {
-    // Fallback to environment variables
-    JWT_SECRET = process.env.JWT_SECRET || "fallback-secret-key-change-in-production"
-    JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "24h"
-  }
-} catch (error) {
-  console.warn("⚠️  Could not load lib/config.js, using environment variables:", error.message)
+  ;({ JWT_SECRET, JWT_EXPIRES_IN } = require("./lib/config"))
+} catch (err) {
   JWT_SECRET = process.env.JWT_SECRET || "fallback-secret-key-change-in-production"
   JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "24h"
 }


### PR DESCRIPTION
## Summary
- centralize JWT_SECRET by exporting from `lib/config.ts`
- reference JWT_SECRET from config across routes and utilities
- load JWT_SECRET from config in websocket server

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684552c373c8832281eec25dfcbdf52f