### PR TITLE
Fix websocket server start command

### DIFF
--- a/start-production.sh
+++ b/start-production.sh
@@ -21,7 +21,7 @@ fi
 # تشغيل WebSocket Server
 if [ "$ENABLE_WEBSOCKET" = "true" ]; then
   echo "📡 تشغيل WebSocket Server..."
-  node -e "require('./lib/websocket-server.js')" &
+  node ./websocket-server.js &
   WS_PID=$!
   echo "WebSocket Server PID: $WS_PID"
 fi


### PR DESCRIPTION
## Summary
- run websocket server using local file rather than requiring compiled lib

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455aff16b88322898c5022ef47249d