### PR TITLE
Add missing path import

### DIFF
--- a/websocket-server.js
+++ b/websocket-server.js
@@ -7,6 +7,7 @@
  */
 
 require("dotenv").config()
+const path = require("path")
 const { createServer } = require("http")
 const { Server } = require("socket.io")
 const WebSocket = require("ws")


### PR DESCRIPTION
## Summary
- require `path` in websocket server

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455afbdc4883229c8c4c1334ea74df