### PR TITLE
Remove eval-based websocket server start

### DIFF
--- a/start-production.sh
+++ b/start-production.sh
@@ -21,7 +21,7 @@ fi
 # تشغيل WebSocket Server
 if [ "$ENABLE_WEBSOCKET" = "true" ]; then
   echo "📡 تشغيل WebSocket Server..."
-  node ./websocket-server.js &
+  node ./websocket-server.js
   WS_PID=$!
   echo "WebSocket Server PID: $WS_PID"
 fi


### PR DESCRIPTION
## Summary
- simplify websocket server start command in `start-production.sh`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456350404c8322bf53e98fac6cd669