### PR TITLE
Implement missing database operations

### DIFF
--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -79,7 +79,7 @@ test('POST /api/devices creates a device', async () => {
 });
 
 test('POST /api/devices/[id]/send sends a message', async () => {
-  const device = await db.createDevice('Send Device');
+  const device = await db.createDevice({ name: 'Send Device' });
 
   const req: any = {
     json: async () => ({ recipient: '123456789', message: 'hi' }),
@@ -132,7 +132,7 @@ test('GET /api/stats returns numeric stats', async () => {
 });
 
 test('GET /api/devices returns devices array', async () => {
-  await db.createDevice('List Device');
+  await db.createDevice({ name: 'List Device' });
   const req: any = { url: 'http://localhost/api/devices', headers: new Headers(), cookies: { get: () => undefined } };
   const res = await devicesGet(req);
   const data = await res.json();

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -15,14 +15,14 @@ afterAll(() => {
 });
 
 test('createDevice inserts a new device', async () => {
-  const device = await db.createDevice('Test Device');
+  const device = await db.createDevice({ name: 'Test Device' });
   expect(device).toBeDefined();
   expect(device.name).toBe('Test Device');
   expect(device.status).toBe('disconnected');
 });
 
 test('createMessage inserts a new message', async () => {
-  const device = await db.createDevice('Message Device');
+  const device = await db.createDevice({ name: 'Message Device' });
   const message = await db.createMessage({
     deviceId: device.id,
     recipient: '123456789',
@@ -36,13 +36,15 @@ test('createMessage inserts a new message', async () => {
 });
 
 test('createAnalyticsEvent stores event and summary returns counts', async () => {
-  const device = await db.createDevice('Analytics Device');
+  const device = await db.createDevice({ name: 'Analytics Device' });
   const event = await db.createAnalyticsEvent({ eventType: 'test_event', deviceId: device.id });
   expect(event).toBeDefined();
   expect(event.eventType).toBe('test_event');
   const summary = await db.getAnalyticsSummary();
   const row = summary.find((s: any) => s.eventType === 'test_event');
   expect(row?.count).toBeGreaterThanOrEqual(1);
+  const events = await db.getAnalyticsEvents(10, 0);
+  expect(events.length).toBeGreaterThan(0);
 });
 
 test('createContact inserts a new contact', async () => {
@@ -50,4 +52,6 @@ test('createContact inserts a new contact', async () => {
   expect(contact).toBeDefined();
   expect(contact.name).toBe('Tester');
   expect(contact.phoneNumber).toBe('12345');
+  const contacts = await db.listContacts();
+  expect(contacts.find((c: any) => c.phoneNumber === '12345')).toBeDefined();
 });


### PR DESCRIPTION
## Summary
- expand `DatabaseManager` with contact and analytics CRUD helpers
- expose `getDeviceById` wrapper
- update API tests and database tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845634cc44883229d234d277c2f0fcd