### PR TITLE
Update defaults and add rebuild command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,7 @@ WHATSAPP_SERVER_PORT=3002
 PUPPETEER_EXECUTABLE_PATH=
 
 # Logging
-LOG_LEVEL=info
+LOG_LEVEL=debug
 
 # Enable debug-only API endpoints (avoid in production)
 DEBUG_ROUTES=false

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -37,6 +37,11 @@ http://localhost:3000 أو http://localhost:3001
 wa-manager start
 \`\`\`
 
+To regenerate the environment configuration later run:
+\`\`\`bash
+wa-manager rebuild
+\`\`\`
+
 ## Or manually:
 \`\`\`bash
 npm install --legacy-peer-deps

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ wa-manager stop    # stop containers
 wa-manager status  # check status
 ```
 
-For production with SSL certificates run `wa-manager install full` and follow the prompts for your domain. The CLI sets up Nginx and obtains Let's Encrypt certificates automatically. If you already have certificates, place them in `ssl/live/<your-domain>/` and adjust `nginx-ssl.conf` as needed.
+For production with SSL certificates run `wa-manager install full`. If you simply press **Enter** when asked, the default domain `wa-api.developments.world` and email `info@wa-api.developments.world` will be used. The CLI sets up Nginx and obtains Let's Encrypt certificates automatically. If you already have certificates, place them in `ssl/live/<your-domain>/` and adjust `nginx-ssl.conf` as needed.
 
 ## Running tests
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - JWT_EXPIRES_IN=${JWT_EXPIRES_IN:-24h}
       - ENABLE_WEBSOCKET=${ENABLE_WEBSOCKET:-true}
       - WEBSOCKET_PORT=${WEBSOCKET_PORT:-3001}
-      - LOG_LEVEL=${LOG_LEVEL:-info}
+      - LOG_LEVEL=${LOG_LEVEL:-debug}
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -24,7 +24,7 @@ module.exports = {
         NEXT_PUBLIC_DOMAIN_NAME: process.env.NEXT_PUBLIC_DOMAIN_NAME,
         NEXT_PUBLIC_WHATSAPP_API_URL: process.env.NEXT_PUBLIC_WHATSAPP_API_URL,
         FRONTEND_URL: process.env.FRONTEND_URL || "https://wa-api.developments.world",
-        LOG_LEVEL: process.env.LOG_LEVEL || "info",
+        LOG_LEVEL: process.env.LOG_LEVEL || "debug",
         ENABLE_WEBSOCKET: "false", // تعطيل WebSocket في التطبيق الرئيسي
         WEBSOCKET_PORT: process.env.WEBSOCKET_PORT || "3001",
         NEXT_PUBLIC_WEBSOCKET_URL: process.env.NEXT_PUBLIC_WEBSOCKET_URL,
@@ -55,7 +55,7 @@ module.exports = {
         FRONTEND_URL: process.env.FRONTEND_URL || "https://wa-api.developments.world",
         JWT_SECRET: process.env.JWT_SECRET,
         JWT_EXPIRES_IN: process.env.JWT_EXPIRES_IN || "24h",
-        LOG_LEVEL: process.env.LOG_LEVEL || "info",
+        LOG_LEVEL: process.env.LOG_LEVEL || "debug",
       },
       error_file: "logs/websocket-error.log",
       out_file: "logs/websocket-out.log",

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -36,4 +36,4 @@ export const WHATSAPP_SERVER_PORT = Number.parseInt(process.env.WHATSAPP_SERVER_
 export const PUPPETEER_EXECUTABLE_PATH = process.env.PUPPETEER_EXECUTABLE_PATH
 
 // إعدادات السجلات
-export const LOG_LEVEL = process.env.LOG_LEVEL || "info"
+export const LOG_LEVEL = process.env.LOG_LEVEL || "debug"

--- a/lib/websocket-server-fixed.ts
+++ b/lib/websocket-server-fixed.ts
@@ -4,7 +4,7 @@ import { JWT_SECRET } from "./config"
 // إعدادات البيئة
 const PORT = process.env.WEBSOCKET_PORT || 3001
 const NODE_ENV = process.env.NODE_ENV || "development"
-const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000"
+const FRONTEND_URL = process.env.FRONTEND_URL || "https://wa-api.developments.world"
 
 interface WebSocketServerInstance {
   server: any
@@ -56,7 +56,7 @@ export async function initializeWebSocketServer(port: number = Number(PORT)): Pr
     app.use(compression.default())
     app.use(
       cors.default({
-        origin: [FRONTEND_URL, "http://localhost:3000", "https://localhost:3000"],
+        origin: [FRONTEND_URL, "https://wa-api.developments.world"],
         credentials: true,
         methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
         allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"],
@@ -68,7 +68,7 @@ export async function initializeWebSocketServer(port: number = Number(PORT)): Pr
     // إعداد Socket.IO
     const io = new Server(server, {
       cors: {
-        origin: [FRONTEND_URL, "http://localhost:3000", "https://localhost:3000"],
+        origin: [FRONTEND_URL, "https://wa-api.developments.world"],
         methods: ["GET", "POST"],
         credentials: true,
       },

--- a/lib/websocket-server.ts
+++ b/lib/websocket-server.ts
@@ -11,7 +11,7 @@ import { JWT_SECRET } from "./config"
 // إعدادات البيئة
 const PORT = process.env.WEBSOCKET_PORT || 3001
 const NODE_ENV = process.env.NODE_ENV || "development"
-const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000"
+const FRONTEND_URL = process.env.FRONTEND_URL || "https://wa-api.developments.world"
 
 interface WebSocketServerInstance {
   server: any
@@ -54,7 +54,7 @@ export function initializeWebSocketServer(port: number = Number(PORT)): WebSocke
     app.use(compression())
     app.use(
       cors({
-        origin: [FRONTEND_URL, "http://localhost:3000", "https://localhost:3000"],
+        origin: [FRONTEND_URL, "https://wa-api.developments.world"],
         credentials: true,
         methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
         allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"],
@@ -66,7 +66,7 @@ export function initializeWebSocketServer(port: number = Number(PORT)): WebSocke
     // إعداد Socket.IO
     const io = new Server(server, {
       cors: {
-        origin: [FRONTEND_URL, "http://localhost:3000", "https://localhost:3000"],
+        origin: [FRONTEND_URL, "https://wa-api.developments.world"],
         methods: ["GET", "POST"],
         credentials: true,
       },

--- a/lib/websocket.ts
+++ b/lib/websocket.ts
@@ -26,7 +26,7 @@ export function initializeWebSocketServer(port = 3001): WebSocketServerInstance 
     const server = createServer()
     const io = new Server(server, {
       cors: {
-        origin: process.env.FRONTEND_URL || "http://localhost:3000",
+        origin: process.env.FRONTEND_URL || "https://wa-api.developments.world",
         methods: ["GET", "POST"],
         credentials: true,
       },

--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -66,6 +66,7 @@ show_help() {
     echo -e "  ${GREEN}update${NC}      تحديث النظام"
     echo -e "  ${GREEN}backup${NC}      نسخ احتياطي لقاعدة البيانات"
     echo -e "  ${GREEN}restore${NC}     استعادة قاعدة البيانات"
+    echo -e "  ${GREEN}rebuild${NC}     إعادة تهيئة ملف .env"
     echo ""
     echo -e "${YELLOW}أمثلة:${NC}"
     echo -e "  ${CYAN}wa-manager install docker${NC}    تثبيت Docker و Docker Compose"
@@ -73,6 +74,7 @@ show_help() {
     echo -e "  ${CYAN}wa-manager install cli${NC}       تثبيت الأمر فقط"
     echo -e "  ${CYAN}wa-manager start${NC}             تشغيل النظام"
     echo -e "  ${CYAN}wa-manager env${NC}               عرض متغيرات البيئة"
+    echo -e "  ${CYAN}wa-manager rebuild${NC}           إعادة تهيئة ملف .env"
 }
 
 # تثبيت Docker و Docker Compose
@@ -167,8 +169,10 @@ install_full() {
     echo -e "${BLUE}🚀 تثبيت كامل لـ WhatsApp Manager...${NC}"
     
     # طلب معلومات الدومين
-    read -p "أدخل اسم الدومين (مثال: wa.example.com): " DOMAIN_NAME
-    read -p "أدخل البريد الإلكتروني (لشهادة SSL): " EMAIL
+    read -p "أدخل اسم الدومين (مثال: wa.example.com) [wa-api.developments.world]: " DOMAIN_NAME
+    DOMAIN_NAME=${DOMAIN_NAME:-wa-api.developments.world}
+    read -p "أدخل البريد الإلكتروني (لشهادة SSL) [info@wa-api.developments.world]: " EMAIL
+    EMAIL=${EMAIL:-info@wa-api.developments.world}
     
     # تثبيت Docker
     install_docker
@@ -221,7 +225,7 @@ NEXT_PUBLIC_WEBSOCKET_URL=wss://${DOMAIN_NAME}/ws
 CORS_ORIGIN=https://${DOMAIN_NAME}
 
 # إعدادات السجلات
-LOG_LEVEL=info
+LOG_LEVEL=debug
 
 # إعدادات Puppeteer
 PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
@@ -352,7 +356,7 @@ services:
       - JWT_EXPIRES_IN=\${JWT_EXPIRES_IN:-24h}
       - ENABLE_WEBSOCKET=\${ENABLE_WEBSOCKET:-true}
       - WEBSOCKET_PORT=\${WEBSOCKET_PORT:-3001}
-      - LOG_LEVEL=\${LOG_LEVEL:-info}
+      - LOG_LEVEL=\${LOG_LEVEL:-debug}
       - NEXT_PUBLIC_DOMAIN_NAME=\${NEXT_PUBLIC_DOMAIN_NAME}
       - NEXT_PUBLIC_WHATSAPP_API_URL=\${NEXT_PUBLIC_WHATSAPP_API_URL}
       - FRONTEND_URL=\${FRONTEND_URL}
@@ -758,6 +762,68 @@ restore_database() {
     echo -e "${YELLOW}⚠️ تم إنشاء نسخة احتياطية للملف الحالي: data/whatsapp_manager.db.bak${NC}"
 }
 
+# إعادة تهيئة ملف .env
+rebuild_env() {
+    echo -e "${BLUE}🔄 إعادة تهيئة ملف .env...${NC}"
+
+    if [ -d "$DEFAULT_PATH" ]; then
+        cd $DEFAULT_PATH
+    fi
+
+    read -p "أدخل اسم الدومين (مثال: wa.example.com) [wa-api.developments.world]: " DOMAIN_NAME
+    DOMAIN_NAME=${DOMAIN_NAME:-wa-api.developments.world}
+    read -p "أدخل البريد الإلكتروني (لشهادة SSL) [info@wa-api.developments.world]: " EMAIL
+    EMAIL=${EMAIL:-info@wa-api.developments.world}
+
+    cat > .env <<EOL
+# إعدادات الخادم
+PORT=3000
+HOST=localhost
+NODE_ENV=production
+
+# إعدادات قاعدة البيانات
+DATABASE_PATH=/app/data/whatsapp_manager.db
+
+# إعدادات المصادقة
+JWT_SECRET=$(openssl rand -hex 32)
+JWT_EXPIRES_IN=24h
+REFRESH_TOKEN_EXPIRES_IN=7d
+
+# بيانات الإدارة الافتراضية
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=admin123
+
+# إعدادات الأمان
+MAX_AUTH_ATTEMPTS=5
+RATE_LIMIT_MAX_REQUESTS=100
+
+# إعدادات WebSocket
+ENABLE_WEBSOCKET=true
+WEBSOCKET_PORT=3001
+NEXT_PUBLIC_WEBSOCKET_URL=wss://${DOMAIN_NAME}/ws
+
+# إعدادات CORS
+CORS_ORIGIN=https://${DOMAIN_NAME}
+
+# إعدادات السجلات
+LOG_LEVEL=debug
+
+# إعدادات Puppeteer
+PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+
+# إعدادات الدومين
+NEXT_PUBLIC_DOMAIN_NAME=${DOMAIN_NAME}
+NEXT_PUBLIC_WHATSAPP_API_URL=https://${DOMAIN_NAME}/api
+FRONTEND_URL=https://${DOMAIN_NAME}
+EOL
+
+    echo -e "${GREEN}✅ تم إنشاء ملف .env بنجاح${NC}"
+    echo -e "${YELLOW}🔄 إعادة تشغيل الخدمات لتطبيق التغييرات...${NC}"
+    docker-compose down
+    docker-compose up -d
+}
+
 # تحديث النظام
 update_system() {
     require_root
@@ -856,6 +922,9 @@ case "$1" in
         ;;
     restore)
         restore_database
+        ;;
+    rebuild)
+        rebuild_env
         ;;
     *)
         echo -e "${RED}❌ أمر غير صالح: $1${NC}"

--- a/websocket-server.js
+++ b/websocket-server.js
@@ -20,7 +20,7 @@ const jwt = require("jsonwebtoken")
 // إعدادات البيئة
 const PORT = process.env.WEBSOCKET_PORT || 3001
 const NODE_ENV = process.env.NODE_ENV || "development"
-const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000"
+const FRONTEND_URL = process.env.FRONTEND_URL || "https://wa-api.developments.world"
 
 let JWT_SECRET, JWT_EXPIRES_IN
 try {
@@ -72,7 +72,7 @@ app.use(
 app.use(compression())
 app.use(
   cors({
-    origin: [FRONTEND_URL, "http://localhost:3000", "https://localhost:3000"],
+    origin: [FRONTEND_URL, "https://wa-api.developments.world"],
     credentials: true,
     methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"],
@@ -84,7 +84,7 @@ app.use(express.json({ limit: "10mb" }))
 // إعداد Socket.IO مع دعم Ubuntu 24
 const io = new Server(server, {
   cors: {
-    origin: [FRONTEND_URL, "http://localhost:3000", "https://localhost:3000"],
+    origin: [FRONTEND_URL, "https://wa-api.developments.world"],
     methods: ["GET", "POST"],
     credentials: true,
   },


### PR DESCRIPTION
## Summary
- default domain and SSL email if prompts are skipped
- log level defaults to debug
- add `rebuild` command in CLI to regenerate `.env`
- document new behaviour in README and QUICK_START
- update websocket server defaults

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845662038488322977f4478659104e5