### PR TITLE
Fix websocket fallback URL

### DIFF
--- a/app/messages/page.tsx
+++ b/app/messages/page.tsx
@@ -37,7 +37,7 @@ export default function MessagesPage() {
 
   useEffect(() => {
     const connectWebSocket = () => {
-      const wsUrl = process.env.NEXT_PUBLIC_WEBSOCKET_URL || "ws://localhost:8080"
+      const wsUrl = process.env.NEXT_PUBLIC_WEBSOCKET_URL || "ws://localhost:3001"
       logger.info("Attempting to connect to WebSocket", { url: wsUrl, attempt: reconnectAttempts.current + 1 })
 
       ws.current = new WebSocket(wsUrl)


### PR DESCRIPTION
## Summary
- use port 3001 as the default websocket fallback

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456935b3848322b6522cf42f467f86