### PR TITLE
Add notification removal logic

### DIFF
--- a/components/notifications.tsx
+++ b/components/notifications.tsx
@@ -6,7 +6,10 @@ import { Button } from "@/components/ui/button"
 import { X, CheckCircle, AlertCircle, AlertTriangle, Info } from "lucide-react"
 
 export function Notifications() {
-  const { notifications, actions } = useAppContext()
+  const {
+    notifications,
+    actions: { removeNotification },
+  } = useAppContext()
 
   if (notifications.length === 0) {
     return null
@@ -50,7 +53,7 @@ export function Notifications() {
               variant="ghost"
               size="sm"
               className="h-6 w-6 p-0"
-              onClick={() => actions.removeNotification(notification.id)}
+              onClick={() => removeNotification(notification.id)}
             >
               <X className="h-4 w-4" />
             </Button>

--- a/lib/app-context.tsx
+++ b/lib/app-context.tsx
@@ -13,6 +13,7 @@ interface AppContextType {
   notifications: Notification[]
   actions: {
     addNotification: (notification: Omit<Notification, "id">) => void
+    removeNotification: (id: string) => void
     clearNotifications: () => void
   }
 }
@@ -21,6 +22,7 @@ const AppContext = createContext<AppContextType>({
   notifications: [],
   actions: {
     addNotification: () => {},
+    removeNotification: () => {},
     clearNotifications: () => {},
   },
 })
@@ -38,6 +40,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
     }, 3000)
   }
 
+  const removeNotification = (id: string) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id))
+  }
+
   const clearNotifications = () => {
     setNotifications([])
   }
@@ -48,6 +54,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         notifications,
         actions: {
           addNotification,
+          removeNotification,
           clearNotifications,
         },
       }}


### PR DESCRIPTION
## Summary
- support removing single notifications via context
- use the new remove method in Notifications component

## Testing
- `npm test` *(fails: cannot find modules, missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68456937559483229f12b64e8f7bd12e