### PR TITLE
Add FRONTEND_URL env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,8 @@ DATABASE_PATH=./data/whatsapp_manager.db
 ENABLE_WEBSOCKET=false
 WEBSOCKET_PORT=3001
 NEXT_PUBLIC_WEBSOCKET_URL=
+# Base URL of the frontend application for CORS checks
+FRONTEND_URL=
 
 # WhatsApp
 WHATSAPP_SERVER_PORT=3002

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Create a `.env` file and provide the required variables:
 - `ADMIN_USERNAME` and `ADMIN_PASSWORD`
 - `DATABASE_PATH` (default: `./data/whatsapp_manager.db`)
 - `JWT_SECRET`
+- `FRONTEND_URL` – base URL of your frontend used by the WebSocket server
 
 Additional options such as `PORT`, `HOST`, and WebSocket settings can also be set.
 


### PR DESCRIPTION
## Summary
- add FRONTEND_URL placeholder to `.env.example`
- document FRONTEND_URL in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845801a05e88322833c977728a8b4c5