### PR TITLE
Add createAuthToken helper

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server"
 import jwt from "jsonwebtoken"
 import { logger } from "./logger"
-import { JWT_SECRET } from "./config"
+import { JWT_SECRET, JWT_EXPIRES_IN } from "./config"
 
 interface AuthResult {
   success: boolean
@@ -47,3 +47,9 @@ export async function verifyAuth(request: NextRequest): Promise<AuthResult> {
     }
   }
 }
+
+export function createAuthToken(user: { id: number; username: string }) {
+  const payload = { userId: user.id, username: user.username }
+  return jwt.sign(payload, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN })
+}
+


### PR DESCRIPTION
## Summary
- implement `createAuthToken` using `jwt.sign`
- export the helper from `lib/middleware.ts`

## Testing
- `npm install` *(fails: command could not finish)*

------
https://chatgpt.com/codex/tasks/task_e_6845801b277c8322a9ffc9d69c922adf