### PR TITLE
Add createAuthToken helper

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server"
 import jwt from "jsonwebtoken"
 import { logger } from "./logger"
-import { JWT_SECRET } from "./config"
+import { JWT_SECRET, JWT_EXPIRES_IN } from "./config"
 
 interface AuthResult {
   success: boolean
@@ -46,4 +46,15 @@ export async function verifyAuth(request: NextRequest): Promise<AuthResult> {
       message: "خطأ في التحقق من المصادقة",
     }
   }
+}
+
+export function createAuthToken(payload: { id: number; username: string }) {
+  return jwt.sign(
+    {
+      userId: payload.id,
+      username: payload.username,
+    },
+    JWT_SECRET,
+    { expiresIn: JWT_EXPIRES_IN },
+  )
 }


### PR DESCRIPTION
## Summary
- implement `createAuthToken` helper using `jwt.sign`
- export JWT_EXPIRES_IN from config for token expiry
- export new helper from `lib/middleware`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458107ab888322be2f537e8159ff9d