### PR TITLE
Fix lock file cleanup

### DIFF
--- a/lib/whatsapp-client-manager.ts
+++ b/lib/whatsapp-client-manager.ts
@@ -71,7 +71,13 @@ class WhatsAppClientManager extends EventEmitter {
 
       // حذف ملفات القفل
       if (fs.existsSync(sessionPath)) {
-        const lockFiles = ["SingletonLock", ".lock", "chrome_debug.log"]
+        const lockFiles = [
+          "SingletonLock",
+          "SingletonCookie",
+          "SingletonSocket",
+          ".lock",
+          "chrome_debug.log",
+        ]
         for (const lockFile of lockFiles) {
           const lockPath = path.join(sessionPath, lockFile)
           if (fs.existsSync(lockPath)) {


### PR DESCRIPTION
## Summary
- remove leftover chromium session lock files during cleanup

## Testing
- `npm test` *(fails: cannot find module '@testing-library/dom')*

------
https://chatgpt.com/codex/tasks/task_e_684592833db483229de7a4296186970e