### PR TITLE
Fix Radix slot dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-select": "^2.1.4",
         "@radix-ui/react-separator": "^1.1.7",
+        "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.12",
         "autoprefixer": "^10.4.21",
         "bcryptjs": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "ts-node": "^10.9.2",
     "whatsapp-web.js": "^1.30.0",
     "ws": "^8.18.2",
-    "zod": "^3.25.56"
+    "zod": "^3.25.56",
+    "@radix-ui/react-slot": "^1.2.3"
   },
   "devDependencies": {
     "@types/compression": "^1.8.1",


### PR DESCRIPTION
## Summary
- include `@radix-ui/react-slot` in dependencies to prevent build errors

## Testing
- `npm test` *(fails: jest-environment-jsdom module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459e09f984832292f2bc4fdbd91f8b