### PR TITLE
Improve database error messaging

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -116,7 +116,14 @@ class DatabaseManager {
 
       this.initialized = true
       logger.info("Database initialized successfully")
-    } catch (error) {
+    } catch (error: any) {
+      if (error.code === "SQLITE_CANTOPEN" || error.code === "EACCES") {
+        logger.error(
+          `Unable to open database file at ${DB_PATH}. ` +
+            `Ensure the data directory exists and is writable. ` +
+            `On the host, run: sudo chown -R 1001:1001 data logs`
+        )
+      }
       logger.error("Database initialization error:", error)
       throw error
     }


### PR DESCRIPTION
## Summary
- clarify database init errors if SQLite can't open the file

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a47817048322a8a28bb819ec05d0