### PR TITLE
Add WebSocket proxy to nginx

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -4,7 +4,12 @@ events {
 
 http {
     upstream whatsapp_manager {
-        server whatsapp-manager-app:3000;
+        server whatsapp-manager:3000;
+    }
+
+    # WebSocket upstream
+    upstream whatsapp_ws {
+        server whatsapp-manager:3001;
     }
 
     server {
@@ -26,6 +31,20 @@ http {
         # Rate limiting
         limit_req_zone $binary_remote_addr zone=login:10m rate=5r/m;
         limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
+
+        # WebSocket endpoint
+        location /ws {
+            proxy_pass http://whatsapp_ws;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 86400;
+            proxy_cache_bypass $http_upgrade;
+        }
 
         location / {
             proxy_pass http://whatsapp_manager;


### PR DESCRIPTION
## Summary
- update upstream in `nginx.conf` to match docker compose container name
- add `/ws` location block for WebSocket traffic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b4ab69c08322a9abb76c1a0b9ea8