### PR TITLE
Fix missing dotenv dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "compression": "^1.8.0",
         "cors": "^2.8.5",
         "date-fns": "^3.6.0",
+        "dotenv": "^16.5.0",
         "express": "^4.21.2",
         "framer-motion": "^10.18.0",
         "helmet": "^7.2.0",
@@ -4662,6 +4663,18 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "compression": "^1.8.0",
     "cors": "^2.8.5",
     "date-fns": "^3.6.0",
+    "dotenv": "^16.5.0",
     "express": "^4.21.2",
     "framer-motion": "^10.18.0",
     "helmet": "^7.2.0",


### PR DESCRIPTION
## Summary
- add dotenv to package.json
- update package-lock.json after install

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm test` *(fails: jest-environment-jsdom not found)*


------
https://chatgpt.com/codex/tasks/task_e_6845ba098d5883228ab1e4a30e453e3c