### PR TITLE
Fix websocket server start

### DIFF
--- a/start-production.sh
+++ b/start-production.sh
@@ -21,9 +21,10 @@ fi
 # تشغيل WebSocket Server
 if [ "$ENABLE_WEBSOCKET" = "true" ]; then
   echo "📡 تشغيل WebSocket Server..."
-  node ./websocket-server.js
+  node ./websocket-server.js &
   WS_PID=$!
   echo "WebSocket Server PID: $WS_PID"
+  trap 'echo "📡 إيقاف WebSocket Server..."; kill $WS_PID' EXIT
 fi
 
 # تشغيل Next.js


### PR DESCRIPTION
## Summary
- run websocket-server.js in the background
- ensure the websocket PID is trapped for cleanup

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c7f266088322a6adfb5e44cf0a64