### PR TITLE
Fix HOST variable for Docker websocket setup

### DIFF
--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -197,7 +197,7 @@ install_full() {
     cat > $DEFAULT_PATH/.env << EOL
 # إعدادات الخادم
 PORT=3000
-HOST=localhost
+HOST=0.0.0.0
 NODE_ENV=production
 
 # إعدادات قاعدة البيانات
@@ -774,7 +774,7 @@ rebuild_env() {
     cat > .env <<EOL
 # إعدادات الخادم
 PORT=3000
-HOST=localhost
+HOST=0.0.0.0
 NODE_ENV=production
 
 # إعدادات قاعدة البيانات


### PR DESCRIPTION
## Summary
- set `HOST=0.0.0.0` when generating `.env` via `wa-manager.sh`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c10c16f48322943f9bf8fd5ccc41