### PR TITLE
Update nginx upstreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ HTTP_PORT=8080 HTTPS_PORT=8443 docker-compose up -d
 ```
 The application will then be served through Nginx on `http://localhost:8080` (or
 `https://localhost:8443` when HTTPS is configured).
+Nginx forwards requests to the `whatsapp-manager` service, so use
+`http://whatsapp-manager` instead of `localhost` in any custom upstreams.
 Make sure the `data` and `logs` directories on the host are writable by UID 1001
 (the user inside the container). Starting with the included installer this
 ownership is adjusted automatically, but if you run the containers manually

--- a/etc/nginx/sites-available/wa-api.developments.world
+++ b/etc/nginx/sites-available/wa-api.developments.world
@@ -26,7 +26,7 @@ server {
 
     # Main Next.js Application
     location / {
-        proxy_pass http://localhost:3000;
+        proxy_pass http://whatsapp-manager:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -40,7 +40,7 @@ server {
 
     # WebSocket Server
     location /socket.io/ {
-        proxy_pass http://localhost:3001;
+        proxy_pass http://whatsapp-manager:3001;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -55,7 +55,7 @@ server {
 
     # WebSocket Direct Connection
     location /ws {
-        proxy_pass http://localhost:3001;
+        proxy_pass http://whatsapp-manager:3001;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -70,7 +70,7 @@ server {
 
     # WebSocket Health Check
     location /websocket/ {
-        proxy_pass http://localhost:3001/;
+        proxy_pass http://whatsapp-manager:3001/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -85,7 +85,7 @@ server {
 
     # Static files
     location /_next/static/ {
-        proxy_pass http://localhost:3000;
+        proxy_pass http://whatsapp-manager:3000;
         proxy_cache_valid 200 1y;
         add_header Cache-Control "public, immutable";
     }


### PR DESCRIPTION
## Summary
- update nginx config to use the `whatsapp-manager` service for upstreams
- mention service name in production setup docs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d0df5eb08322a4bb112acbd32849