### PR TITLE
Add test:ci script and clarify testing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,20 @@ For production with SSL certificates run `wa-manager install full`. If you simpl
 
 ## Running tests
 
-Install dependencies and run the test suite:
+Install dependencies and run the test suite. The tests rely on dev
+dependencies such as **Jest**, so be sure to install everything first:
 
 ```bash
 npm install
 npm test
 ```
+
+For automated environments you can also run:
+
+```bash
+npm run test:ci
+```
+which installs dependencies using `npm ci` before running Jest.
 
 ## Development login test
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "production": "npm run build && npm start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest",
+    "test:ci": "npm ci && npm test"
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.14",


### PR DESCRIPTION
## Summary
- clarify that Jest is installed with `npm install` before running tests
- add a `test:ci` script that installs dependencies before running tests

## Testing
- `npm test` *(fails: jest not found)*
- `npm run test:ci` *(fails to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845d0e32960832282f23b5a8bb4f6cb