### PR TITLE
Update WebSocket server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ For local development you can launch it manually with:
 ```bash
 node websocket-server.js
 ```
+Before running this command make sure the project dependencies are installed:
+
+```bash
+npm install # or `pnpm install`
+```
+Docker builds run this step for you during `docker-compose up`, but if you start
+the WebSocket server manually you need to install the packages yourself.
 
 For process management you can also use PM2 with the provided
 `ecosystem.config.js`:


### PR DESCRIPTION
## Summary
- add note about installing dependencies before starting the WebSocket server

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d0e09c048322858d831e237103e3