### PR TITLE
Fix WebSocket proxy examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ these using the `HTTP_PORT` and `HTTPS_PORT` environment variables when starting
 the stack. This is handy when another web server already occupies the default
 ports.
 
+When using the provided Nginx examples inside Docker, make sure the upstream
+addresses target the `whatsapp-manager` service instead of `localhost`.
+
 ```bash
 HTTP_PORT=8080 HTTPS_PORT=8443 docker-compose up -d
 ```
@@ -107,6 +110,12 @@ For local development you can launch it manually with:
 
 ```bash
 node websocket-server.js
+```
+
+Make sure to install dependencies first:
+
+```bash
+npm install
 ```
 
 For process management you can also use PM2 with the provided

--- a/etc/nginx/sites-available/wa-api.developments.world
+++ b/etc/nginx/sites-available/wa-api.developments.world
@@ -26,7 +26,7 @@ server {
 
     # Main Next.js Application
     location / {
-        proxy_pass http://localhost:3000;
+        proxy_pass http://whatsapp-manager:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -40,7 +40,7 @@ server {
 
     # WebSocket Server
     location /socket.io/ {
-        proxy_pass http://localhost:3001;
+        proxy_pass http://whatsapp-manager:3001;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -55,7 +55,7 @@ server {
 
     # WebSocket Direct Connection
     location /ws {
-        proxy_pass http://localhost:3001;
+        proxy_pass http://whatsapp-manager:3001;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -70,7 +70,7 @@ server {
 
     # WebSocket Health Check
     location /websocket/ {
-        proxy_pass http://localhost:3001/;
+        proxy_pass http://whatsapp-manager:3001/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -85,7 +85,7 @@ server {
 
     # Static files
     location /_next/static/ {
-        proxy_pass http://localhost:3000;
+        proxy_pass http://whatsapp-manager:3000;
         proxy_cache_valid 200 1y;
         add_header Cache-Control "public, immutable";
     }

--- a/etc/nginx/sites-available/whatsapp-manager.conf
+++ b/etc/nginx/sites-available/whatsapp-manager.conf
@@ -39,7 +39,7 @@ server {
 
     # التطبيق الرئيسي
     location / {
-        proxy_pass http://localhost:3000;
+        proxy_pass http://whatsapp-manager:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -67,7 +67,7 @@ server {
 
     # WebSocket
     location /socket.io/ {
-        proxy_pass http://localhost:3001;
+        proxy_pass http://whatsapp-manager:3001;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -80,7 +80,7 @@ server {
 
     # API
     location /api/ {
-        proxy_pass http://localhost:3000;
+        proxy_pass http://whatsapp-manager:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';

--- a/nginx-ssl.conf
+++ b/nginx-ssl.conf
@@ -47,7 +47,7 @@ server {
     
     # API proxy
     location /api {
-        proxy_pass http://localhost:3000;
+        proxy_pass http://whatsapp-manager:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -65,7 +65,7 @@ server {
     
     # WebSocket proxy
     location /ws {
-        proxy_pass http://localhost:3001;
+        proxy_pass http://whatsapp-manager:3001;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
@@ -82,7 +82,7 @@ server {
     
     # Main application - Next.js server
     location / {
-        proxy_pass http://localhost:3000;
+        proxy_pass http://whatsapp-manager:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';

--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -197,7 +197,7 @@ install_full() {
     cat > $DEFAULT_PATH/.env << EOL
 # إعدادات الخادم
 PORT=3000
-HOST=localhost
+HOST=0.0.0.0
 NODE_ENV=production
 
 # إعدادات قاعدة البيانات
@@ -774,7 +774,7 @@ rebuild_env() {
     cat > .env <<EOL
 # إعدادات الخادم
 PORT=3000
-HOST=localhost
+HOST=0.0.0.0
 NODE_ENV=production
 
 # إعدادات قاعدة البيانات


### PR DESCRIPTION
## Summary
- correct upstream addresses in example nginx configs
- document how to install deps before launching WebSocket server manually
- explain that nginx containers must proxy to the `whatsapp-manager` service

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c10c16f48322943f9bf8fd5ccc41