### PR TITLE
Add external API endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,6 @@ LOG_LEVEL=debug
 
 # Enable debug-only API endpoints (avoid in production)
 DEBUG_ROUTES=false
+
+# External API key used for programmatic access
+EXTERNAL_API_KEY=

--- a/README.md
+++ b/README.md
@@ -178,6 +178,23 @@ npm run test:ci
 ```
 which installs dependencies using `npm ci` before running Jest.
 
+## External API
+
+Set `EXTERNAL_API_KEY` in your `.env` file to enable programmatic access from
+other projects. Use the `/api/external/send-message` endpoint to send WhatsApp
+messages.
+
+Example request:
+
+```bash
+curl -X POST http://localhost:3000/api/external/send-message \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-Key: your-key' \
+  -d '{"deviceId":1,"recipient":"+123456789","message":"Hello"}'
+```
+
+The endpoint returns a JSON object indicating success or failure.
+
 ## Development login test
 
 The repository includes a small component `components/login-test.tsx` for

--- a/app/api/external/send-message/route.ts
+++ b/app/api/external/send-message/route.ts
@@ -1,0 +1,98 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { type NextRequest, NextResponse } from "next/server";
+import { whatsappManager } from "@/lib/whatsapp-client-manager";
+import { db } from "@/lib/database";
+import { ValidationSchemas } from "@/lib/validation";
+import { EXTERNAL_API_KEY } from "@/lib/config";
+
+export async function POST(request: NextRequest) {
+  try {
+    const apiKey =
+      request.headers.get("x-api-key") ||
+      new URL(request.url).searchParams.get("apiKey");
+
+    if (!EXTERNAL_API_KEY || apiKey !== EXTERNAL_API_KEY) {
+      return NextResponse.json(
+        { success: false, error: "غير مصرح" },
+        { status: 401 },
+      );
+    }
+
+    const { deviceId, recipient, message } = await request.json();
+
+    if (
+      typeof deviceId !== "number" ||
+      typeof recipient !== "string" ||
+      typeof message !== "string"
+    ) {
+      return NextResponse.json(
+        { success: false, error: "بيانات غير صالحة" },
+        { status: 400 },
+      );
+    }
+
+    await db.ensureInitialized();
+
+    const messageData = ValidationSchemas.message({
+      to: recipient,
+      message,
+    });
+
+    if (!messageData) {
+      return NextResponse.json(
+        { success: false, error: "بيانات الرسالة غير صحيحة" },
+        { status: 400 },
+      );
+    }
+
+    const device = await db.getDeviceById(deviceId);
+    if (!device) {
+      return NextResponse.json(
+        { success: false, error: "الجهاز غير موجود" },
+        { status: 404 },
+      );
+    }
+
+    if (!whatsappManager.isClientReady(deviceId)) {
+      return NextResponse.json(
+        { success: false, error: "الجهاز غير متصل" },
+        { status: 400 },
+      );
+    }
+
+    const success = await whatsappManager.sendMessage(
+      deviceId,
+      messageData.to,
+      messageData.message,
+    );
+
+    if (success) {
+      return NextResponse.json({
+        success: true,
+        message: "تم إرسال الرسالة بنجاح",
+        timestamp: new Date().toISOString(),
+      });
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: "فشل في إرسال الرسالة",
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "خطأ في الخادم",
+        details: error instanceof Error ? error.message : "Unknown error",
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -37,3 +37,6 @@ export const PUPPETEER_EXECUTABLE_PATH = process.env.PUPPETEER_EXECUTABLE_PATH
 
 // إعدادات السجلات
 export const LOG_LEVEL = process.env.LOG_LEVEL || "debug"
+
+// مفتاح API للاستخدامات الخارجية
+export const EXTERNAL_API_KEY = process.env.EXTERNAL_API_KEY

--- a/tests/external-api.test.ts
+++ b/tests/external-api.test.ts
@@ -1,0 +1,75 @@
+import { afterAll, beforeAll, expect, jest, test } from '@jest/globals';
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (data: any, init?: any) => ({
+      status: init?.status || 200,
+      json: async () => data,
+    }),
+  },
+}));
+
+jest.mock('@/lib/validation', () => ({
+  ValidationSchemas: {
+    message: jest.fn().mockReturnValue({ to: '123456789', message: 'hi' }),
+  },
+}));
+
+jest.mock('@/lib/whatsapp-client-manager', () => {
+  return {
+    whatsappManager: {
+      sendMessage: jest.fn().mockResolvedValue(true),
+      isClientReady: jest.fn().mockReturnValue(true),
+    },
+  };
+});
+
+let db: any;
+let sendExternalPost: any;
+let whatsappManagerMock: any;
+
+beforeAll(async () => {
+  process.env.DATABASE_PATH = ':memory:';
+  process.env.EXTERNAL_API_KEY = 'testkey';
+  process.env.ADMIN_USERNAME = `test_admin_${Date.now()}`;
+  const dbModule = await import('../lib/database');
+  db = dbModule.db;
+  await dbModule.initializeDatabase();
+
+  const managerModule = await import('../lib/whatsapp-client-manager');
+  whatsappManagerMock = managerModule.whatsappManager;
+
+  sendExternalPost = (await import('../app/api/external/send-message/route')).POST;
+});
+
+afterAll(() => {
+  if (db) db.close();
+});
+
+test('rejects requests without API key', async () => {
+  const req: any = {
+    json: async () => ({ deviceId: 1, recipient: '123', message: 'hi' }),
+    headers: new Headers(),
+    url: 'http://localhost/api/external/send-message',
+  };
+
+  const res = await sendExternalPost(req);
+  const data = await res.json();
+  expect(res.status).toBe(401);
+  expect(data.success).toBe(false);
+});
+
+test('sends message when API key is valid', async () => {
+  const device = await db.createDevice({ name: 'External Device' });
+  const req: any = {
+    json: async () => ({ deviceId: device.id, recipient: '123456789', message: 'hi' }),
+    headers: new Headers({ 'X-API-Key': 'testkey', 'Content-Type': 'application/json' }),
+    url: 'http://localhost/api/external/send-message',
+  };
+
+  const res = await sendExternalPost(req);
+  const data = await res.json();
+  expect(res.status).toBe(200);
+  expect(data.success).toBe(true);
+  expect(whatsappManagerMock.sendMessage).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- expose `EXTERNAL_API_KEY` in config
- document new external API in README and `.env.example`
- implement `POST /api/external/send-message`
- add jest tests for the new endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684630c9ce08832287ab8e3d8836fe65