### PR TITLE
Improve websocket configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN mkdir -p data logs && \
 USER whatsapp
 
 EXPOSE 3000
+EXPOSE 3001
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:3000/api/health || exit 1

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ these using the `HTTP_PORT` and `HTTPS_PORT` environment variables when starting
 the stack. This is handy when another web server already occupies the default
 ports.
 
+The WebSocket server listens on port `3001`. The compose file now exposes this
+port so you can connect directly if desired. Set `NEXT_PUBLIC_WEBSOCKET_URL`
+to `ws://localhost:3001` for local setups or `wss://<your-domain>/ws` when using
+Nginx as a reverse proxy.
+
 When using the provided Nginx examples inside Docker, make sure the upstream
 addresses target the `whatsapp-manager` service instead of `localhost`.
 
@@ -135,6 +140,11 @@ For process management you can also use PM2 with the provided
 ```bash
 pm2 start ecosystem.config.js
 ```
+
+The ecosystem file runs the main server and the standalone WebSocket
+process. Make sure `NEXT_PUBLIC_WEBSOCKET_URL` in your `.env` reflects the
+public address (for example `wss://example.com/ws`) so clients can connect
+when running under PM2.
 
 ## CLI installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     restart: unless-stopped
     ports:
       - "3000:3000"
+      - "${WEBSOCKET_PORT:-3001}:${WEBSOCKET_PORT:-3001}"
     environment:
       - NODE_ENV=production
       - DATABASE_PATH=/app/data/whatsapp_manager.db
@@ -18,6 +19,7 @@ services:
       - JWT_EXPIRES_IN=${JWT_EXPIRES_IN:-24h}
       - ENABLE_WEBSOCKET=${ENABLE_WEBSOCKET:-true}
       - WEBSOCKET_PORT=${WEBSOCKET_PORT:-3001}
+      - NEXT_PUBLIC_WEBSOCKET_URL=${NEXT_PUBLIC_WEBSOCKET_URL:-ws://localhost:${WEBSOCKET_PORT:-3001}}
       - LOG_LEVEL=${LOG_LEVEL:-debug}
     volumes:
       - ./data:/app/data

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -25,7 +25,9 @@ module.exports = {
         LOG_LEVEL: process.env.LOG_LEVEL || "debug",
         ENABLE_WEBSOCKET: "false", // تعطيل WebSocket في التطبيق الرئيسي
         WEBSOCKET_PORT: process.env.WEBSOCKET_PORT || "3001",
-        NEXT_PUBLIC_WEBSOCKET_URL: process.env.NEXT_PUBLIC_WEBSOCKET_URL,
+        NEXT_PUBLIC_WEBSOCKET_URL:
+          process.env.NEXT_PUBLIC_WEBSOCKET_URL ||
+          `ws://localhost:${process.env.WEBSOCKET_PORT || "3001"}`,
       },
       error_file: "logs/app-error.log",
       out_file: "logs/app-out.log",


### PR DESCRIPTION
## Summary
- expose websocket port in Dockerfile
- map websocket port and configure websocket URL in docker-compose
- set a default websocket URL in the PM2 config
- document websocket port exposure and PM2 usage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684634f4ebb08322ac6b0f687b999270