### PR TITLE
Implement live device updates with shared WebSocket provider

### DIFF
--- a/app/client-layout.tsx
+++ b/app/client-layout.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 import { Tajawal } from "next/font/google"
 import { AppProvider } from "@/lib/app-context"
+import { WebSocketProvider } from "@/lib/websocket-provider"
 import "./globals.css"
 
 const tajawal = Tajawal({
@@ -23,7 +24,9 @@ export default function ClientLayout({
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
       </head>
       <body className={tajawal.className}>
-        <AppProvider>{children}</AppProvider>
+        <WebSocketProvider>
+          <AppProvider>{children}</AppProvider>
+        </WebSocketProvider>
       </body>
     </html>
   )

--- a/lib/websocket-provider.tsx
+++ b/lib/websocket-provider.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { createContext, useContext, type ReactNode } from "react"
+import { useWebSocket } from "@/lib/use-websocket"
+
+export interface IWebSocketContext {
+  socket: any | null
+  connected: boolean
+  connecting: boolean
+  error: string | null
+  lastMessage: any
+  connect: () => void
+  disconnect: () => void
+  emit: (event: string, data?: any) => boolean
+  on: (event: string, callback: (data: any) => void) => () => void
+}
+
+const WebSocketContext = createContext<IWebSocketContext>({
+  socket: null,
+  connected: false,
+  connecting: false,
+  error: null,
+  lastMessage: null,
+  connect: () => {},
+  disconnect: () => {},
+  emit: () => false,
+  on: () => () => {},
+})
+
+export function WebSocketProvider({ children }: { children: ReactNode }) {
+  const ws = useWebSocket({})
+
+  return (
+    <WebSocketContext.Provider value={ws}>{children}</WebSocketContext.Provider>
+  )
+}
+
+export function useWebSocketContext() {
+  return useContext(WebSocketContext)
+}


### PR DESCRIPTION
## Summary
- add a `WebSocketProvider` to share one socket connection
- wrap the application in the new provider
- listen for `device_status_changed` and `qr_code_generated` events
- update device state on the fly instead of reloading from API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684675bd2a608322aa5caa04cb72b2c4