### PR TITLE
Fix Docker build by including scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,9 +18,11 @@ data/
 ssl/
 
 # Development files and documentation
-scripts/
+scripts/*
+!scripts/init-database.js
 tests/
 *.sh
+!start-production.sh
 *.md
 *.test.*
 *.spec.*


### PR DESCRIPTION
## Summary
- ensure `start-production.sh` and `scripts/init-database.js` are copied into the Docker image

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install --ignore-scripts`
- `npm test` *(fails: Environment variable JWT_SECRET is required)*

------
https://chatgpt.com/codex/tasks/task_e_6846910a7e0083228952560135d231e2