### PR TITLE
Fix Docker build dependency issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ WORKDIR /app
 
 COPY package*.json .npmrc ./
 
-RUN npm install --omit=dev && npm cache clean --force
+RUN npm install --legacy-peer-deps && npm cache clean --force
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- install dev dependencies during Docker build to include TypeScript

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684692533a6083228e2e896d25aeb7cc