### PR TITLE
Add test environment example

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,42 @@
+# Authentication
+JWT_SECRET=test-secret
+JWT_EXPIRES_IN=1h
+REFRESH_TOKEN_EXPIRES_IN=1h
+MAX_AUTH_ATTEMPTS=5
+
+# Admin credentials
+ADMIN_USERNAME=test
+ADMIN_PASSWORD=test
+
+# Server settings
+PORT=4000
+HOST=127.0.0.1
+CORS_ORIGIN=
+RATE_LIMIT_MAX_REQUESTS=20
+
+# Database
+DATABASE_PATH=/tmp/whatsapp_manager_test.db
+
+# WebSocket
+ENABLE_WEBSOCKET=false
+WEBSOCKET_PORT=4001
+NEXT_PUBLIC_WEBSOCKET_URL=ws://localhost:4001/ws
+FRONTEND_URL=
+
+# Automatically reconnect all devices when the server starts
+AUTO_CONNECT_DEVICES=false
+
+# Restart policy for Docker containers
+RESTART_POLICY=no
+
+# WhatsApp
+WHATSAPP_SERVER_PORT=4002
+
+# Logging
+LOG_LEVEL=debug
+
+# Enable debug-only API endpoints
+DEBUG_ROUTES=true
+
+# External API key used for programmatic access
+EXTERNAL_API_KEY=test-key

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ out/
 
 # environment files
 .env*
+!.env.example
+!.env.test
 
 # logs and data
 data/

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ wa-manager status   # حالة التشغيل
 استخدم `wa-manager install full` لإعداد Nginx وشهادة SSL تلقائيًا.
 
 ## تشغيل الاختبارات
-تتطلب الاختبارات وجود جميع الاعتماديات وملف `.env.test`:
+تتطلب الاختبارات وجود جميع الاعتماديات ونسخة من ملف `.env.test`:
 ```bash
-cp .env.example .env.test
+cp .env.test .env
 PUPPETEER_SKIP_DOWNLOAD=1 npm install --ignore-scripts
 npm test
 ```


### PR DESCRIPTION
## Summary
- add `.env.test` with safe defaults for automated tests
- allow `.env.test` in git
- document how to run tests using the new env file

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install --ignore-scripts`
- `npm test` *(fails: cannot find module '@testing-library/dom', missing env vars, and missing sqlite bindings)*

------
https://chatgpt.com/codex/tasks/task_e_68469e3850888322aca8428fd7202815