### PR TITLE
Make toast removal delay configurable

### DIFF
--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -9,7 +9,48 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const DEFAULT_TOAST_REMOVE_DELAY = 5000
+let toastRemoveDelay = DEFAULT_TOAST_REMOVE_DELAY
+
+interface ToastConfig {
+  removeDelay: number
+  setRemoveDelay: (delay: number) => void
+}
+
+const ToastConfigContext = React.createContext<ToastConfig>({
+  removeDelay: DEFAULT_TOAST_REMOVE_DELAY,
+  setRemoveDelay: () => {},
+})
+
+export function ToastConfigProvider({
+  children,
+  removeDelay = DEFAULT_TOAST_REMOVE_DELAY,
+}: React.PropsWithChildren<{ removeDelay?: number }>) {
+  const setRemoveDelay = React.useCallback((delay: number) => {
+    toastRemoveDelay = delay
+  }, [])
+
+  React.useEffect(() => {
+    setRemoveDelay(removeDelay)
+  }, [removeDelay, setRemoveDelay])
+
+  const value = React.useMemo(
+    () => ({ removeDelay, setRemoveDelay }),
+    [removeDelay, setRemoveDelay]
+  )
+
+  return (
+    <ToastConfigContext.Provider value={value}>
+      {children}
+    </ToastConfigContext.Provider>
+  )
+}
+
+export const useToastConfig = () => React.useContext(ToastConfigContext)
+
+export const setToastRemoveDelay = (delay: number) => {
+  toastRemoveDelay = delay
+}
 
 type ToasterToast = ToastProps & {
   id: string
@@ -69,7 +110,7 @@ const addToRemoveQueue = (toastId: string) => {
       type: "REMOVE_TOAST",
       toastId: toastId,
     })
-  }, TOAST_REMOVE_DELAY)
+  }, toastRemoveDelay)
 
   toastTimeouts.set(toastId, timeout)
 }
@@ -191,4 +232,10 @@ function useToast() {
   }
 }
 
-export { useToast, toast }
+export {
+  useToast,
+  toast,
+  ToastConfigProvider,
+  useToastConfig,
+  setToastRemoveDelay,
+}

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -9,7 +9,48 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const DEFAULT_TOAST_REMOVE_DELAY = 5000
+let toastRemoveDelay = DEFAULT_TOAST_REMOVE_DELAY
+
+interface ToastConfig {
+  removeDelay: number
+  setRemoveDelay: (delay: number) => void
+}
+
+const ToastConfigContext = React.createContext<ToastConfig>({
+  removeDelay: DEFAULT_TOAST_REMOVE_DELAY,
+  setRemoveDelay: () => {},
+})
+
+export function ToastConfigProvider({
+  children,
+  removeDelay = DEFAULT_TOAST_REMOVE_DELAY,
+}: React.PropsWithChildren<{ removeDelay?: number }>) {
+  const setRemoveDelay = React.useCallback((delay: number) => {
+    toastRemoveDelay = delay
+  }, [])
+
+  React.useEffect(() => {
+    setRemoveDelay(removeDelay)
+  }, [removeDelay, setRemoveDelay])
+
+  const value = React.useMemo(
+    () => ({ removeDelay, setRemoveDelay }),
+    [removeDelay, setRemoveDelay]
+  )
+
+  return (
+    <ToastConfigContext.Provider value={value}>
+      {children}
+    </ToastConfigContext.Provider>
+  )
+}
+
+export const useToastConfig = () => React.useContext(ToastConfigContext)
+
+export const setToastRemoveDelay = (delay: number) => {
+  toastRemoveDelay = delay
+}
 
 type ToasterToast = ToastProps & {
   id: string
@@ -69,7 +110,7 @@ const addToRemoveQueue = (toastId: string) => {
       type: "REMOVE_TOAST",
       toastId: toastId,
     })
-  }, TOAST_REMOVE_DELAY)
+  }, toastRemoveDelay)
 
   toastTimeouts.set(toastId, timeout)
 }
@@ -191,4 +232,10 @@ function useToast() {
   }
 }
 
-export { useToast, toast }
+export {
+  useToast,
+  toast,
+  ToastConfigProvider,
+  useToastConfig,
+  setToastRemoveDelay,
+}


### PR DESCRIPTION
## Summary
- set default toast removal delay to 5 seconds
- allow customizing removal delay through `ToastConfigProvider`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68469e3c1bcc8322b458c63b730fa0d0