### PR TITLE
Remove next.js build ignore flags

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,12 +4,6 @@ const nextConfig = {
   experimental: {
     serverComponentsExternalPackages: ["whatsapp-web.js", "puppeteer", "fluent-ffmpeg"],
   },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   webpack: (config, { isServer }) => {
     if (isServer) {
       // إضافة externals للمكتبات التي تعمل فقط على الخادم


### PR DESCRIPTION
## Summary
- enforce lint and TypeScript checks by removing `ignoreDuringBuilds` and `ignoreBuildErrors` from `next.config.js`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_68469e3a5be08322a6e9a111c52aed61