### PR TITLE
Refine Docker install step and clean dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ WORKDIR /app
 
 COPY package*.json .npmrc ./
 
-RUN npm install --legacy-peer-deps && npm cache clean --force
+RUN npm ci --omit=dev && npm cache clean --force
 
 COPY . .
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,8 +66,7 @@
         "babel-jest": "^29.7.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "ts-jest": "^29.3.4",
-        "typescript": "^5.8.3"
+        "ts-jest": "^29.3.4"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "babel-jest": "^29.7.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "ts-jest": "^29.3.4",
-    "typescript": "^5.8.3"
+    "ts-jest": "^29.3.4"
   }
 }


### PR DESCRIPTION
## Summary
- use `npm ci --omit=dev` during Docker build
- remove duplicate `typescript` entry from devDependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a1e5213083229e096c98eddf4ed6