### PR TITLE
Fix Docker build missing dev dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,13 +43,17 @@ WORKDIR /app
 
 COPY package*.json .npmrc ./
 
-RUN npm ci --omit=dev && npm cache clean --force
+# Install all dependencies including dev packages for the build step
+RUN npm ci && npm cache clean --force
 
 COPY . .
 
 RUN chmod +x start-production.sh
 
 RUN npm run build
+
+# Remove development dependencies after the build to keep the image slim
+RUN npm prune --production && npm cache clean --force
 
 RUN addgroup --gid 1001 nodejs && \
     adduser --system --uid 1001 --gid 1001 whatsapp


### PR DESCRIPTION
## Summary
- install dev dependencies for build stage in Dockerfile
- prune dev packages after building

## Testing
- `npm test` *(fails: Environment variable JWT_SECRET is required)*

------
https://chatgpt.com/codex/tasks/task_e_6846ab35fba4832285411f35ec8125e3