### PR TITLE
Fix Dockerfile build env handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
-ENV NODE_ENV=production
+ENV NODE_ENV=development
 
 WORKDIR /app
 
@@ -51,6 +51,9 @@ COPY . .
 RUN chmod +x start-production.sh
 
 RUN npm run build
+
+# Switch to production mode before pruning dev dependencies
+ENV NODE_ENV=production
 
 # Remove development dependencies after the build to keep the image slim
 RUN npm prune --production && npm cache clean --force


### PR DESCRIPTION
## Summary
- keep development env during build then switch to production

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install --ignore-scripts`
- `npm test` *(fails: Environment variable JWT_SECRET is required)*
- `docker compose version` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846af3615688322bb205d979c893049