### PR TITLE
Fix chown logic in startup script

### DIFF
--- a/start-production.sh
+++ b/start-production.sh
@@ -10,7 +10,9 @@ fi
 # التأكد من وجود المجلدات الضرورية
 mkdir -p logs data backups
 # Ensure proper ownership so the container can write to the database and logs
-chown -R 1001:1001 data logs
+if [ "$(id -u)" -eq 0 ]; then
+  chown -R 1001:1001 data logs
+fi
 
 # إنشاء قاعدة البيانات إذا لم تكن موجودة
 if [ ! -f "data/whatsapp_manager.db" ]; then


### PR DESCRIPTION
## Summary
- ensure `start-production.sh` only changes ownership when running as root

## Testing
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_6846af37b24c8322b6ec81341f3b9f85