### PR TITLE
Replace console with logger in API routes

### DIFF
--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,12 +1,13 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { cookies } from "next/headers"
+import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 export async function POST(request: NextRequest) {
   try {
-    console.log("🔍 POST /api/auth/logout - Starting request")
+    logger.info("🔍 POST /api/auth/logout - Starting request")
 
     // حذف ملف تعريف الارتباط
     const cookieStore = cookies()
@@ -18,7 +19,7 @@ export async function POST(request: NextRequest) {
       timestamp: new Date().toISOString(),
     })
   } catch (error) {
-    console.error("❌ Error in POST /api/auth/logout:", error)
+    logger.error("❌ Error in POST /api/auth/logout:", error)
     return NextResponse.json(
       {
         success: false,

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { verifyToken, getUserById } from "@/lib/auth"
 import { db } from "@/lib/database"
+import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -30,7 +31,7 @@ export async function GET(request: NextRequest) {
       },
     })
   } catch (error) {
-    console.error("Auth verification error:", error)
+    logger.error("Auth verification error:", error)
     return NextResponse.json({ success: false, message: "خطأ في الخادم" }, { status: 500 })
   }
 }

--- a/app/api/devices/[id]/connect/route.ts
+++ b/app/api/devices/[id]/connect/route.ts
@@ -2,24 +2,25 @@ import { type NextRequest, NextResponse } from "next/server"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
+import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    console.log(`🔍 POST /api/devices/${params.id}/connect - Starting request`)
+    logger.info(`🔍 POST /api/devices/${params.id}/connect - Starting request`)
 
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      console.log("❌ Authentication failed:", authResult.message)
+      logger.info("❌ Authentication failed:", authResult.message)
       return NextResponse.json(authResult, { status: 401 })
     }
 
     const deviceId = Number.parseInt(params.id)
     if (isNaN(deviceId)) {
-      console.log("❌ Invalid device ID:", params.id)
+      logger.info("❌ Invalid device ID:", params.id)
       return NextResponse.json(
         {
           success: false,
@@ -30,12 +31,12 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
       )
     }
 
-    console.log(`📱 Connecting device ID: ${deviceId}`)
+    logger.info(`📱 Connecting device ID: ${deviceId}`)
 
     // التحقق من وجود الجهاز
     const device = await db.getDeviceById(deviceId)
     if (!device) {
-      console.log("❌ Device not found:", deviceId)
+      logger.info("❌ Device not found:", deviceId)
       return NextResponse.json(
         {
           success: false,
@@ -46,11 +47,11 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
       )
     }
 
-    console.log("✅ Device found:", device.name)
+    logger.info("✅ Device found:", device.name)
 
     // التحقق من حالة الجهاز
     if (device.status === "connected" || device.status === "connecting") {
-      console.log("⚠️ Device already connected/connecting")
+      logger.info("⚠️ Device already connected/connecting")
       return NextResponse.json(
         {
           success: false,
@@ -71,7 +72,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
     const success = await whatsappManager.createClient(deviceId, device.name)
 
     if (success) {
-      console.log("✅ WhatsApp client creation initiated successfully")
+      logger.info("✅ WhatsApp client creation initiated successfully")
       return NextResponse.json({
         success: true,
         message: "تم بدء عملية الاتصال بنجاح",
@@ -79,7 +80,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
         timestamp: new Date().toISOString(),
       })
     } else {
-      console.log("❌ Failed to create WhatsApp client")
+      logger.info("❌ Failed to create WhatsApp client")
       return NextResponse.json(
         {
           success: false,
@@ -90,7 +91,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
       )
     }
   } catch (error) {
-    console.error(`❌ Error connecting device ${params.id}:`, error)
+    logger.error(`❌ Error connecting device ${params.id}:`, error)
     return NextResponse.json(
       {
         success: false,

--- a/app/api/devices/[id]/disconnect/route.ts
+++ b/app/api/devices/[id]/disconnect/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from "next/server"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
+import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -59,7 +60,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
       )
     }
   } catch (error) {
-    console.error("Error disconnecting device:", error)
+    logger.error("Error disconnecting device:", error)
     return NextResponse.json(
       {
         success: false,

--- a/app/api/devices/[id]/route.ts
+++ b/app/api/devices/[id]/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
+import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -60,7 +61,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
       timestamp: new Date().toISOString(),
     })
   } catch (error) {
-    console.error("Error getting device:", error)
+    logger.error("Error getting device:", error)
     return NextResponse.json(
       {
         success: false,
@@ -129,7 +130,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
       timestamp: new Date().toISOString(),
     })
   } catch (error) {
-    console.error("Error updating device:", error)
+    logger.error("Error updating device:", error)
     return NextResponse.json(
       {
         success: false,
@@ -199,7 +200,7 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
       )
     }
   } catch (error) {
-    console.error("Error deleting device:", error)
+    logger.error("Error deleting device:", error)
     return NextResponse.json(
       {
         success: false,

--- a/app/api/devices/[id]/send-bulk/route.ts
+++ b/app/api/devices/[id]/send-bulk/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from "next/server"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
+import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -95,7 +96,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
       timestamp: new Date().toISOString(),
     })
   } catch (error) {
-    console.error("Error sending bulk messages:", error)
+    logger.error("Error sending bulk messages:", error)
     return NextResponse.json(
       {
         success: false,

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { verifyAuth } from "@/lib/auth"
+import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -34,12 +35,12 @@ const notifications = [
 
 export async function GET(request: NextRequest) {
   try {
-    console.log("🔍 GET /api/notifications - Starting request")
+    logger.info("🔍 GET /api/notifications - Starting request")
 
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      console.log("❌ Authentication failed:", authResult.message)
+      logger.info("❌ Authentication failed:", authResult.message)
       return NextResponse.json(
         {
           success: false,
@@ -50,7 +51,7 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    console.log("✅ Authentication successful")
+    logger.info("✅ Authentication successful")
 
     // معالجة المعلمات
     const url = new URL(request.url)
@@ -67,7 +68,7 @@ export async function GET(request: NextRequest) {
       timestamp: new Date().toISOString(),
     })
   } catch (error) {
-    console.error("❌ Error in GET /api/notifications:", error)
+    logger.error("❌ Error in GET /api/notifications:", error)
     return NextResponse.json(
       {
         success: false,
@@ -82,12 +83,12 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    console.log("🔍 POST /api/notifications - Starting request")
+    logger.info("🔍 POST /api/notifications - Starting request")
 
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      console.log("❌ Authentication failed:", authResult.message)
+      logger.info("❌ Authentication failed:", authResult.message)
       return NextResponse.json(
         {
           success: false,
@@ -98,7 +99,7 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    console.log("✅ Authentication successful")
+    logger.info("✅ Authentication successful")
 
     // قراءة البيانات
     const body = await request.json()
@@ -120,7 +121,7 @@ export async function POST(request: NextRequest) {
       timestamp: new Date().toISOString(),
     })
   } catch (error) {
-    console.error("❌ Error in POST /api/notifications:", error)
+    logger.error("❌ Error in POST /api/notifications:", error)
     return NextResponse.json(
       {
         success: false,

--- a/app/api/socket/route.ts
+++ b/app/api/socket/route.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server"
 import { getWebSocketServer, initializeWebSocketServer } from "@/lib/websocket-server"
+import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -39,7 +40,7 @@ export async function GET(request: NextRequest) {
       },
     )
   } catch (error) {
-    console.error("Error checking WebSocket server:", error)
+    logger.error("Error checking WebSocket server:", error)
     return new Response(
       JSON.stringify({
         error: "WebSocket server error",
@@ -79,7 +80,7 @@ export async function POST(request: NextRequest) {
 
     return new Response(JSON.stringify({ success: true }), { status: 200 })
   } catch (error) {
-    console.error("Error in socket POST:", error)
+    logger.error("Error in socket POST:", error)
     return new Response(JSON.stringify({ error: "Internal server error" }), { status: 500 })
   }
 }

--- a/app/api/stats/system/route.ts
+++ b/app/api/stats/system/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from "next/server"
 import { verifyAuth } from "@/lib/auth"
 import os from "os"
 import fs from "fs"
+import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -63,7 +64,7 @@ export async function GET(request: NextRequest) {
       },
     })
   } catch (error) {
-    console.error("System stats error:", error)
+    logger.error("System stats error:", error)
     return NextResponse.json({ error: "Failed to get system stats" }, { status: 500 })
   }
 }

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,18 +1,19 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
+import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 export async function GET(request: NextRequest) {
   try {
-    console.log("🔍 GET /api/users - Starting request")
+    logger.info("🔍 GET /api/users - Starting request")
 
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      console.log("❌ Authentication failed:", authResult.message)
+      logger.info("❌ Authentication failed:", authResult.message)
       return NextResponse.json(
         {
           success: false,
@@ -23,7 +24,7 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    console.log("✅ Authentication successful")
+    logger.info("✅ Authentication successful")
 
     // جلب المستخدمين من قاعدة البيانات
     const admins = await db.getAllAdmins()
@@ -44,7 +45,7 @@ export async function GET(request: NextRequest) {
       timestamp: new Date().toISOString(),
     })
   } catch (error) {
-    console.error("❌ Error in GET /api/users:", error)
+    logger.error("❌ Error in GET /api/users:", error)
     return NextResponse.json(
       {
         success: false,


### PR DESCRIPTION
## Summary
- replace `console` statements with `logger` in API routes
- import `logger` from `@/lib/logger`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846af145b3c8322b52da9c9ff469d55