### PR TITLE
Fix NODE_ENV order in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,11 @@ RUN apt-get update && apt-get install -y \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
-ENV NODE_ENV=development
 
 WORKDIR /app
 
 COPY package*.json .npmrc ./
+ENV NODE_ENV=development
 
 # Install all dependencies including dev packages for the build step
 RUN npm ci && npm cache clean --force


### PR DESCRIPTION
## Summary
- move `NODE_ENV=development` next to `npm ci` step
- keep setting `NODE_ENV=production` after build

## Testing
- `npm test` *(fails: command not found)*
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b1ceada88322a4e841d3b2989f89