### PR TITLE
Move serverExternalPackages out of experimental block

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,8 @@
 const path = require('path')
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    serverExternalPackages: ["whatsapp-web.js", "puppeteer", "fluent-ffmpeg"],
-  },
+  serverExternalPackages: ["whatsapp-web.js", "puppeteer", "fluent-ffmpeg"],
+
   webpack: (config, { isServer }) => {
     if (isServer) {
       // إضافة externals للمكتبات التي تعمل فقط على الخادم


### PR DESCRIPTION
## Summary
- move `serverExternalPackages` to the top-level config and remove the empty `experimental` block

## Testing
- `npx -y next build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6846b8b919088322aadf88e27ecf1df8