### PR TITLE
Fix dockerignore to include README

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,7 +23,6 @@ scripts/*
 tests/
 *.sh
 !start-production.sh
-*.md
 *.test.*
 *.spec.*
 


### PR DESCRIPTION
## Summary
- include markdown docs in build context by removing the `*.md` ignore rule

## Testing
- `npm test` *(fails: jest not found)*
- `docker build -t whatsapp-manager-test .` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bfd6efa883229e1ce6dd14896bcb