### PR TITLE
Add production credential warnings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,12 @@
 # Authentication
-# Replace with a strong secret in production
+# Replace with a strong secret in production. DO NOT use this default value.
 JWT_SECRET=fallback-secret-key-change-in-production
 JWT_EXPIRES_IN=24h
 REFRESH_TOKEN_EXPIRES_IN=7d
 MAX_AUTH_ATTEMPTS=5
 
 # Admin credentials
-# Change these defaults immediately
+# Change these defaults immediately! DO NOT USE IN PRODUCTION.
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=admin123
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ docker-compose up --build -d
 ```bash
 cp .env.example .env
 ```
+
+### تحذير أمني
+قبل تشغيل التطبيق في بيئة الإنتاج، تأكد من تغيير المتغيرات الافتراضية
+مثل `ADMIN_USERNAME`, `ADMIN_PASSWORD` و`JWT_SECRET` في ملف البيئة أو داخل
+`docker-compose.yml`. استخدام القيم الافتراضية قد يعرّض النظام للاختراق.
 ### شرح المتغيرات
 - `ADMIN_USERNAME` و`ADMIN_PASSWORD`: بيانات الدخول للوحة التحكم.
 - `JWT_SECRET`: مفتاح التوقيع للرموز.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,6 @@
 version: '3.8'
+# WARNING: Replace ADMIN_USERNAME, ADMIN_PASSWORD and JWT_SECRET
+# with strong values before deploying to production.
 
 services:
   whatsapp-manager:
@@ -10,6 +12,7 @@ services:
       - "3000:3000"
       - "${WEBSOCKET_PORT:-3001}:${WEBSOCKET_PORT:-3001}"
     environment:
+#      Replace default credentials before using in production
       - NODE_ENV=production
       - DATABASE_PATH=/app/data/whatsapp_manager.db
       - ADMIN_USERNAME=admin


### PR DESCRIPTION
## Summary
- warn about changing default credentials in the README
- highlight replacing default credentials in docker-compose.yml and .env.example

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bfcf087c8322901a9ccf604b5974