### PR TITLE
Fix dynamic route param handling

### DIFF
--- a/app/api/contacts/[id]/route.ts
+++ b/app/api/contacts/[id]/route.ts
@@ -6,14 +6,18 @@ import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
 import { ValidationSchemas } from "@/lib/validation"
 
-export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
   try {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
       return NextResponse.json(authResult, { status: 401 })
     }
 
-    const contactId = Number.parseInt(params.id)
+    const contactId = Number.parseInt(id)
     if (isNaN(contactId)) {
       return NextResponse.json(
         { success: false, error: "معرف غير صالح", timestamp: new Date().toISOString() },
@@ -43,14 +47,18 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   }
 }
 
-export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
   try {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
       return NextResponse.json(authResult, { status: 401 })
     }
 
-    const contactId = Number.parseInt(params.id)
+    const contactId = Number.parseInt(id)
     if (isNaN(contactId)) {
       return NextResponse.json(
         { success: false, error: "معرف غير صالح", timestamp: new Date().toISOString() },
@@ -83,14 +91,18 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
   }
 }
 
-export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
   try {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
       return NextResponse.json(authResult, { status: 401 })
     }
 
-    const contactId = Number.parseInt(params.id)
+    const contactId = Number.parseInt(id)
     if (isNaN(contactId)) {
       return NextResponse.json(
         { success: false, error: "معرف غير صالح", timestamp: new Date().toISOString() },

--- a/app/api/devices/[id]/connect/route.ts
+++ b/app/api/devices/[id]/connect/route.ts
@@ -7,9 +7,13 @@ import { logger } from "@/lib/logger"
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
-export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
   try {
-    logger.info(`🔍 POST /api/devices/${params.id}/connect - Starting request`)
+    logger.info(`🔍 POST /api/devices/${id}/connect - Starting request`)
 
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
@@ -18,9 +22,9 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
       return NextResponse.json(authResult, { status: 401 })
     }
 
-    const deviceId = Number.parseInt(params.id)
+    const deviceId = Number.parseInt(id)
     if (isNaN(deviceId)) {
-      logger.info("❌ Invalid device ID:", params.id)
+      logger.info("❌ Invalid device ID:", id)
       return NextResponse.json(
         {
           success: false,
@@ -91,7 +95,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
       )
     }
   } catch (error) {
-    logger.error(`❌ Error connecting device ${params.id}:`, error)
+    logger.error(`❌ Error connecting device ${id}:`, error)
     return NextResponse.json(
       {
         success: false,

--- a/app/api/devices/[id]/disconnect/route.ts
+++ b/app/api/devices/[id]/disconnect/route.ts
@@ -7,7 +7,11 @@ import { logger } from "@/lib/logger"
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
-export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
   try {
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
@@ -15,7 +19,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
       return NextResponse.json(authResult, { status: 401 })
     }
 
-    const deviceId = Number.parseInt(params.id)
+    const deviceId = Number.parseInt(id)
     if (isNaN(deviceId)) {
       return NextResponse.json(
         {

--- a/app/api/devices/[id]/route.ts
+++ b/app/api/devices/[id]/route.ts
@@ -7,7 +7,11 @@ import { logger } from "@/lib/logger"
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
-export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
   try {
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
@@ -15,7 +19,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
       return NextResponse.json(authResult, { status: 401 })
     }
 
-    const deviceId = Number.parseInt(params.id)
+    const deviceId = Number.parseInt(id)
     if (isNaN(deviceId)) {
       return NextResponse.json(
         {
@@ -73,7 +77,11 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   }
 }
 
-export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
   try {
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
@@ -81,7 +89,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
       return NextResponse.json(authResult, { status: 401 })
     }
 
-    const deviceId = Number.parseInt(params.id)
+    const deviceId = Number.parseInt(id)
     if (isNaN(deviceId)) {
       return NextResponse.json(
         {
@@ -142,7 +150,11 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
   }
 }
 
-export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
   try {
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
@@ -150,7 +162,7 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
       return NextResponse.json(authResult, { status: 401 })
     }
 
-    const deviceId = Number.parseInt(params.id)
+    const deviceId = Number.parseInt(id)
     if (isNaN(deviceId)) {
       return NextResponse.json(
         {

--- a/app/api/devices/[id]/schedule/route.ts
+++ b/app/api/devices/[id]/schedule/route.ts
@@ -7,14 +7,18 @@ import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
 import { ValidationSchemas } from "@/lib/validation"
 
-export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
   try {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
       return NextResponse.json(authResult, { status: 401 })
     }
 
-    const deviceId = Number.parseInt(params.id)
+    const deviceId = Number.parseInt(id)
     if (isNaN(deviceId)) {
       return NextResponse.json({ success: false, error: "معرف الجهاز غير صالح", timestamp: new Date().toISOString() }, { status: 400 })
     }

--- a/app/api/devices/[id]/send-bulk/route.ts
+++ b/app/api/devices/[id]/send-bulk/route.ts
@@ -7,7 +7,11 @@ import { logger } from "@/lib/logger"
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
-export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
   try {
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
@@ -15,7 +19,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
       return NextResponse.json(authResult, { status: 401 })
     }
 
-    const deviceId = Number.parseInt(params.id)
+    const deviceId = Number.parseInt(id)
     if (isNaN(deviceId)) {
       return NextResponse.json(
         {

--- a/app/api/devices/[id]/send-media/route.ts
+++ b/app/api/devices/[id]/send-media/route.ts
@@ -7,14 +7,18 @@ import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
 import { ValidationSchemas } from "@/lib/validation"
 
-export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
   try {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
       return NextResponse.json(authResult, { status: 401 })
     }
 
-    const deviceId = Number.parseInt(params.id)
+    const deviceId = Number.parseInt(id)
     if (isNaN(deviceId)) {
       return NextResponse.json({ success: false, error: "معرف الجهاز غير صالح", timestamp: new Date().toISOString() }, { status: 400 })
     }

--- a/app/api/devices/[id]/send/route.ts
+++ b/app/api/devices/[id]/send/route.ts
@@ -8,9 +8,13 @@ import { logger } from "@/lib/logger"
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
-export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
   try {
-    logger.info(`🔍 POST /api/devices/${params.id}/send - Starting request`)
+    logger.info(`🔍 POST /api/devices/${id}/send - Starting request`)
 
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
@@ -19,9 +23,9 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
       return NextResponse.json(authResult, { status: 401 })
     }
 
-    const deviceId = Number.parseInt(params.id)
+    const deviceId = Number.parseInt(id)
     if (isNaN(deviceId)) {
-      logger.info("❌ Invalid device ID:", params.id)
+      logger.info("❌ Invalid device ID:", id)
       return NextResponse.json(
         {
           success: false,
@@ -107,7 +111,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
       )
     }
   } catch (error) {
-    logger.error(`❌ Error sending message from device ${params.id}:`, error)
+    logger.error(`❌ Error sending message from device ${id}:`, error)
     return NextResponse.json(
       {
         success: false,


### PR DESCRIPTION
## Summary
- adjust dynamic `[id]` routes to await `params`
- handle the resolved `id` variable inside each handler

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c6f1ac508322a5117109d6a0e8e9