### PR TITLE
Fix change-password request type

### DIFF
--- a/app/api/auth/change-password/route.ts
+++ b/app/api/auth/change-password/route.ts
@@ -1,11 +1,11 @@
-import { NextResponse } from "next/server"
+import { type NextRequest, NextResponse } from "next/server"
 import { AuthService } from "@/lib/auth"
 import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
   try {
     const { currentPassword, newPassword } = await request.json()
 


### PR DESCRIPTION
## Summary
- use `NextRequest` for POST `/api/auth/change-password` to match AuthService expectations

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c94189c48322ab39f7194ac83e09