### PR TITLE
Fix changePassword user property mismatch

### DIFF
--- a/app/api/auth/change-password/route.ts
+++ b/app/api/auth/change-password/route.ts
@@ -20,7 +20,7 @@ export async function POST(request: NextRequest) {
     }
 
     // تغيير كلمة المرور
-    const result = await AuthService.changePassword(user.id, currentPassword, newPassword)
+    const result = await AuthService.changePassword(user.userId, currentPassword, newPassword)
 
     if (result.success) {
       logger.info(`Password changed successfully for user: ${user.username}`)


### PR DESCRIPTION
## Summary
- use `user.userId` when calling `changePassword`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ca2df3dc8322a69e72fa3e7c0e00