### PR TITLE
Fix changePassword user property mismatch

### DIFF
--- a/app/api/auth/change-password/route.ts
+++ b/app/api/auth/change-password/route.ts
@@ -20,7 +20,7 @@ export async function POST(request: NextRequest) {
     }
 
     // تغيير كلمة المرور
-    const result = await AuthService.changePassword(user.id, currentPassword, newPassword)
+    const result = await AuthService.changePassword(user.userId, currentPassword, newPassword)
 
     if (result.success) {
       logger.info(`Password changed successfully for user: ${user.username}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "@babel/runtime": "^7.27.6",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
+        "@types/bcryptjs": "^2.4.6",
         "@types/compression": "^1.8.1",
         "@types/cors": "^2.8.19",
         "@types/express": "^4.17.23",
@@ -4511,6 +4512,13 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@babel/runtime": "^7.27.6",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@types/bcryptjs": "^2.4.6",
     "@types/compression": "^1.8.1",
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.23",


### PR DESCRIPTION
## Summary
- use `user.userId` when calling `changePassword`
- add missing types for bcryptjs

## Testing
- `npm test` *(fails: Environment variable JWT_SECRET is required)*

------
https://chatgpt.com/codex/tasks/task_e_6846ca2df3dc8322a69e72fa3e7c0e00