### PR TITLE
Fix refresh token extraction logic

### DIFF
--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -5,7 +5,8 @@ export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 export async function POST(request: NextRequest) {
-  const refreshToken = request.cookies.get("refresh-token")?.value || (await request.json()?.refreshToken)
+  const body = await request.json().catch(() => null)
+  const refreshToken = request.cookies.get("refresh-token")?.value || body?.refreshToken
 
   if (!refreshToken) {
     return NextResponse.json({ success: false, message: "Refresh token missing" }, { status: 401 })


### PR DESCRIPTION
## Summary
- handle invalid JSON in refresh token route
- fall back to refresh-token cookie when JSON body is missing

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'next/server' and other typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846d86363548322bdf9e61e82595a66