### PR TITLE
Fix duplicate engines entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,8 +118,5 @@
     "puppeteer-core": {
       "tar-fs": "2.1.3"
     }
-  },
-  "engines": {
-    "node": ">=20"
   }
 }


### PR DESCRIPTION
## Summary
- remove redundant bottom `engines` block from `package.json`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470f0f576c83228c23132b304fb615