### PR TITLE
Fix websocket path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,8 +24,8 @@ DATABASE_PATH=./data/whatsapp_manager.db
 ENABLE_WEBSOCKET=false
 WEBSOCKET_PORT=3001
 # Default WebSocket URL clients should connect to
-# Include the /ws path by default
-NEXT_PUBLIC_WEBSOCKET_URL=ws://localhost:3001/ws
+# Include the /ws/socket.io path by default
+NEXT_PUBLIC_WEBSOCKET_URL=ws://localhost:3001/ws/socket.io
 # Allowed frontend origin used by the WebSocket server
 FRONTEND_URL=
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cp .env.example .env
 - `PORT` و`HOST`: إعدادات الخادم الرئيسي.
 - `DATABASE_PATH`: مسار قاعدة البيانات (الافتراضي `./data/whatsapp_manager.db`).
 - `ENABLE_WEBSOCKET` و`WEBSOCKET_PORT`: تشغيل خادم WebSocket وتحديد المنفذ.
-- `NEXT_PUBLIC_WEBSOCKET_URL`: عنوان الاتصال من الواجهة.
+- `NEXT_PUBLIC_WEBSOCKET_URL`: عنوان الاتصال من الواجهة ويجب أن ينتهي بالمسار `/ws/socket.io`.
 - `LOG_LEVEL`: مستوى السجلات (`debug`، `info`، إلخ).
 - `RESTART_POLICY`: سياسة إعادة تشغيل الحاويات عند استخدام Docker.
 

--- a/app/messages/page.tsx
+++ b/app/messages/page.tsx
@@ -41,10 +41,9 @@ export default function MessagesPage() {
 
   useEffect(() => {
     const connectWebSocket = () => {
-      let wsUrl = process.env.NEXT_PUBLIC_WEBSOCKET_URL || "ws://localhost:3001/ws"
-      if (!wsUrl.endsWith("/ws")) {
-        wsUrl = wsUrl.replace(/\/$/, "") + "/ws"
-      }
+      let wsUrl =
+        process.env.NEXT_PUBLIC_WEBSOCKET_URL ||
+        "ws://localhost:3001/ws/socket.io"
       logger.info("Attempting to connect to WebSocket", { url: wsUrl, attempt: reconnectAttempts.current + 1 })
 
       ws.current = new WebSocket(wsUrl)

--- a/lib/use-websocket.ts
+++ b/lib/use-websocket.ts
@@ -19,13 +19,15 @@ interface WebSocketState {
 
 export function useWebSocket(options: UseWebSocketOptions = {}) {
   const {
-    url = process.env.NEXT_PUBLIC_WEBSOCKET_URL || "http://localhost:3001/ws",
+    url =
+      process.env.NEXT_PUBLIC_WEBSOCKET_URL ||
+      "http://localhost:3001/ws/socket.io",
     token,
     deviceId,
     autoConnect = true,
   } = options
 
-  const fullUrl = url.endsWith("/ws") ? url : url.replace(/\/$/, "") + "/ws"
+  const fullUrl = url
 
   const [state, setState] = useState<WebSocketState>({
     connected: false,

--- a/lib/websocket-server.ts
+++ b/lib/websocket-server.ts
@@ -65,6 +65,7 @@ export function initializeWebSocketServer(port: number = Number(PORT)): WebSocke
 
     // إعداد Socket.IO
     const io = new Server(server, {
+      path: "/ws/socket.io",
       cors: {
         origin: [FRONTEND_URL, "https://wa-api.developments.world"],
         methods: ["GET", "POST"],


### PR DESCRIPTION
## Summary
- set socket.io path on websocket server
- make websocket URL configurable without forced /ws suffix
- update sample .env and docs for new /ws/socket.io path

## Testing
- `npm install`
- `npm test` *(fails: Cannot find module '@testing-library/dom' and missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_6847102c1ac08322a61f67eade8c0704