### PR TITLE
Fix ringColor placement in tailwind config

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,11 +9,11 @@ const config: Config = {
     "*.{js,ts,jsx,tsx,mdx}"
   ],
   theme: {
-        ringColor: {
-                ring: 'hsl(var(--ring))',
-                'sidebar-ring': 'hsl(var(--sidebar-ring))'
-        },
         extend: {
+                ringColor: {
+                        ring: 'hsl(var(--ring))',
+                        'sidebar-ring': 'hsl(var(--sidebar-ring))',
+                },
                 colors: {
                         background: 'hsl(var(--background))',
                         foreground: 'hsl(var(--foreground))',


### PR DESCRIPTION
## Summary
- move `ringColor` under `theme.extend` in tailwind config

## Testing
- `npm test` *(fails: Could not locate the bindings file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684727295a088322996357d91f9d64ec