### PR TITLE
Fix lint errors across project

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useState, useCallback } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Activity, MessageSquare, Smartphone, Users, RefreshCw, AlertCircle } from "lucide-react"
@@ -54,7 +54,7 @@ export default function DashboardPage() {
     return `${minutes} دقيقة`
   }
 
-  const fetchStats = async () => {
+  const fetchStats = useCallback(async () => {
     try {
       setError(null)
       setLoading(true)
@@ -117,7 +117,7 @@ export default function DashboardPage() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [])
 
   const handleRefresh = () => {
     fetchStats()
@@ -125,7 +125,7 @@ export default function DashboardPage() {
 
   useEffect(() => {
     fetchStats()
-  }, [])
+  }, [fetchStats])
 
   if (loading) {
     return (

--- a/app/devices/page.tsx
+++ b/app/devices/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -34,7 +34,7 @@ export default function DevicesPage() {
 
   useEffect(() => {
     fetchDevices()
-  }, [])
+  }, [fetchDevices])
 
   useEffect(() => {
     const offStatus = on("device_status_changed", (data: any) => {
@@ -57,7 +57,7 @@ export default function DevicesPage() {
     }
   }, [on])
 
-  const fetchDevices = async () => {
+  const fetchDevices = useCallback(async () => {
     try {
       setIsLoading(true)
       const response = await fetch("/api/devices", {
@@ -89,7 +89,7 @@ export default function DevicesPage() {
     } finally {
       setIsLoading(false)
     }
-  }
+  }, [actions])
 
   const handleAddDevice = async () => {
     if (!newDeviceName.trim()) {

--- a/app/diagnostics/page.tsx
+++ b/app/diagnostics/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -48,9 +48,9 @@ export default function DiagnosticsPage() {
 
   useEffect(() => {
     checkSystemStatus()
-  }, [])
+  }, [checkSystemStatus])
 
-  const checkSystemStatus = async () => {
+  const checkSystemStatus = useCallback(async () => {
     setIsRefreshing(true)
 
     // جلب متغيرات البيئة من الخادم
@@ -66,7 +66,7 @@ export default function DiagnosticsPage() {
     await checkDatabaseStatus()
 
     setIsRefreshing(false)
-  }
+  }, [])
 
   const checkApiStatus = async () => {
     try {

--- a/app/messages/page.tsx
+++ b/app/messages/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect, useRef, useCallback } from "react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -37,7 +37,7 @@ export default function MessagesPage() {
         ws.current.close()
       }
     }
-  }, [deviceFilter])
+  }, [deviceFilter, fetchMessages, fetchDevices])
 
   useEffect(() => {
     const connectWebSocket = () => {
@@ -139,7 +139,7 @@ export default function MessagesPage() {
     }
   }, [on, actions])
 
-  const fetchMessages = async () => {
+  const fetchMessages = useCallback(async () => {
     try {
       setIsLoading(true)
       const url =
@@ -164,9 +164,9 @@ export default function MessagesPage() {
     } finally {
       setIsLoading(false)
     }
-  }
+  }, [deviceFilter, actions])
 
-  const fetchDevices = async () => {
+  const fetchDevices = useCallback(async () => {
     try {
       const response = await fetch("/api/devices")
       const data: { success: boolean; devices?: Device[] } = await response.json()
@@ -184,7 +184,7 @@ export default function MessagesPage() {
         message: "فشل في جلب بيانات الأجهزة",
       })
     }
-  }
+  }, [actions])
 
   const getDeviceName = (deviceId: number) => {
     const device = devices.find((d) => d.id === deviceId)

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -41,9 +41,9 @@ export default function SettingsPage() {
   useEffect(() => {
     fetchUserInfo()
     fetchApiToken()
-  }, [])
+  }, [fetchUserInfo])
 
-  const fetchUserInfo = async () => {
+  const fetchUserInfo = useCallback(async () => {
     try {
       const response = await fetch("/api/auth/me")
       if (response.ok) {
@@ -57,7 +57,7 @@ export default function SettingsPage() {
     } finally {
       setIsLoading(false)
     }
-  }
+  }, [actions])
 
   const fetchApiToken = async () => {
     try {

--- a/components/login-test.tsx
+++ b/components/login-test.tsx
@@ -14,9 +14,6 @@ import { logger } from "@/lib/logger"
 // When NODE_ENV is set to "production" it will render nothing so it isn't
 // included in the UI.
 export default function LoginTest() {
-  if (process.env.NODE_ENV === "production") {
-    return null
-  }
   const [credentials, setCredentials] = useState({
     username: "admin",
     password: "admin123!@#",
@@ -28,6 +25,10 @@ export default function LoginTest() {
     details?: any
   } | null>(null)
   const [showPassword, setShowPassword] = useState(false)
+
+  if (process.env.NODE_ENV === "production") {
+    return null
+  }
 
   const testLogin = async () => {
     setIsLoading(true)

--- a/lib/websocket-server.ts
+++ b/lib/websocket-server.ts
@@ -446,8 +446,10 @@ export function stopWebSocketServer(): void {
   }
 }
 
-export default {
+const websocketServerApi = {
   initializeWebSocketServer,
   getWebSocketServer,
   stopWebSocketServer,
 }
+
+export default websocketServerApi

--- a/lib/websocket.ts
+++ b/lib/websocket.ts
@@ -121,8 +121,10 @@ export function stopWebSocketServer(): void {
   }
 }
 
-export default {
+const websocketApi = {
   initializeWebSocketServer,
   getWebSocketServer,
   stopWebSocketServer,
 }
+
+export default websocketApi


### PR DESCRIPTION
## Summary
- fix React hook dependencies in pages
- stabilize fetch functions with `useCallback`
- reorder hook usage in login test component
- export websocket utilities via variables to avoid anonymous default export

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '@testing-library/dom', expect(res.status).toBe(201) etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68472765ae948322ab7edeba27241c6a