### PR TITLE
Refactor toast configuration provider

### DIFF
--- a/hooks/use-toast.tsx
+++ b/hooks/use-toast.tsx
@@ -22,7 +22,7 @@ const ToastConfigContext = React.createContext<ToastConfig>({
   setRemoveDelay: () => {},
 })
 
-export function ToastConfigProvider({
+export function ToastConfigContextProvider({
   children,
   removeDelay = DEFAULT_TOAST_REMOVE_DELAY,
 }: React.PropsWithChildren<{ removeDelay?: number }>) {


### PR DESCRIPTION
## Summary
- rename `ToastConfigProvider` to `ToastConfigContextProvider`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847462997188322845c714353fef37e