### PR TITLE
Fix location message type error

### DIFF
--- a/lib/whatsapp-client-manager.ts
+++ b/lib/whatsapp-client-manager.ts
@@ -804,7 +804,7 @@ class WhatsAppClientManager extends EventEmitter {
         throw new Error("Invalid phone number format");
       }
       const formattedNumber = this.formatPhoneNumber(recipient);
-      const loc = new Location(latitude, longitude, description);
+      const loc = new Location(latitude, longitude, { name: description });
       const sentMessage = await whatsappClient.client.sendMessage(
         formattedNumber,
         loc,


### PR DESCRIPTION
## Summary
- fix sendLocationMessage to pass correct options to `Location`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684751a19ac88322afd1a56da315562a