### PR TITLE
Use temp DB during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ WORKDIR /app
 
 COPY package.json package-lock.json .npmrc ./
 ENV NODE_ENV=development
+# Use a temporary database during build to avoid SQLite locking errors
+ENV DATABASE_PATH=/tmp/whatsapp_manager_build.db
 
 # Install all dependencies including dev packages for the build step
 RUN npm ci && npm cache clean --force
@@ -57,6 +59,8 @@ RUN npm run build
 
 # Switch to production mode before pruning dev dependencies
 ENV NODE_ENV=production
+# Use the real database location at runtime
+ENV DATABASE_PATH=/app/data/whatsapp_manager.db
 
 # Remove development dependencies after the build to keep the image slim
 RUN npm prune --production && npm cache clean --force

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ cp .env.example .env
 - `JWT_EXPIRES_IN` و`REFRESH_TOKEN_EXPIRES_IN`: مدة صلاحية التوكنات.
 - `PORT` و`HOST`: إعدادات الخادم الرئيسي.
 - `DATABASE_PATH`: مسار قاعدة البيانات (الافتراضي `./data/whatsapp_manager.db`).
+  أثناء بناء صورة Docker يتم تعيين المتغير إلى مسار مؤقت داخل `/tmp`
+  لتجنب تعارضات SQLite، ويُعاد إلى المسار الافتراضي عند التشغيل.
 - `ENABLE_WEBSOCKET` و`WEBSOCKET_PORT`: تشغيل خادم WebSocket وتحديد المنفذ.
 - `NEXT_PUBLIC_WEBSOCKET_URL`: عنوان الاتصال من الواجهة ويجب أن ينتهي بالمسار `/ws/socket.io`.
 - `LOG_LEVEL`: مستوى السجلات (`debug`، `info`، إلخ).


### PR DESCRIPTION
## Summary
- avoid SQLite lock errors by changing `DATABASE_PATH` to use `/tmp` when building the image
- document this temporary path in README

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install --ignore-scripts`
- `npm test` *(fails: Could not locate the bindings file `better_sqlite3.node`)*

------
https://chatgpt.com/codex/tasks/task_e_6847c92faa948322acdcc96af2fa68ff