### PR TITLE
Fix Next.js Html error

### DIFF
--- a/app/client-layout.tsx
+++ b/app/client-layout.tsx
@@ -1,16 +1,10 @@
 
+"use client"
+
 import type React from "react"
-import { Tajawal } from "next/font/google"
 import { AppProvider } from "@/lib/app-context"
 import { WebSocketProvider } from "@/lib/websocket-context"
 import "./globals.css"
-
-const tajawal = Tajawal({
-  subsets: ["arabic", "latin"],
-  display: "swap",
-  weight: ["400", "500", "700"],
-})
-
 
 export default function ClientLayout({
   children,
@@ -18,15 +12,8 @@ export default function ClientLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="ar" dir="rtl">
-      <head>
-        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-      </head>
-      <body className={tajawal.className}>
-        <WebSocketProvider>
-          <AppProvider>{children}</AppProvider>
-        </WebSocketProvider>
-      </body>
-    </html>
+    <WebSocketProvider>
+      <AppProvider>{children}</AppProvider>
+    </WebSocketProvider>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type React from "react"
 import type { Metadata } from "next"
+import { Tajawal } from "next/font/google"
 import ClientLayout from "./client-layout"
 
 export const metadata: Metadata = {
@@ -15,10 +16,25 @@ export const viewport = {
   initialScale: 1,
 }
 
+const tajawal = Tajawal({
+  subsets: ["arabic", "latin"],
+  display: "swap",
+  weight: ["400", "500", "700"],
+})
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  return <ClientLayout>{children}</ClientLayout>
+  return (
+    <html lang="ar" dir="rtl">
+      <head>
+        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+      </head>
+      <body className={tajawal.className}>
+        <ClientLayout>{children}</ClientLayout>
+      </body>
+    </html>
+  )
 }


### PR DESCRIPTION
## Summary
- restructure RootLayout to directly include `<html>` and `<body>`
- convert `ClientLayout` to a client component and use it as a wrapper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ddc2cf7883228ec755bb612dfb05