### PR TITLE
Fix SQLite init during Next build

### DIFF
--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -19,6 +19,9 @@ export async function GET(request: NextRequest) {
       )
     }
 
+    // Ensure the database is initialized before querying
+    await db.ensureInitialized()
+
     const url = new URL(request.url)
     const limit = Number.parseInt(url.searchParams.get("limit") || "50")
     const offset = Number.parseInt(url.searchParams.get("offset") || "0")

--- a/app/api/contacts/[id]/route.ts
+++ b/app/api/contacts/[id]/route.ts
@@ -17,6 +17,9 @@ export async function GET(
       return NextResponse.json(authResult, { status: 401 })
     }
 
+    // Ensure database is initialized
+    await db.ensureInitialized()
+
     const contactId = Number.parseInt(id)
     if (isNaN(contactId)) {
       return NextResponse.json(
@@ -57,6 +60,9 @@ export async function PUT(
     if (!authResult.success) {
       return NextResponse.json(authResult, { status: 401 })
     }
+
+    // Ensure database is initialized
+    await db.ensureInitialized()
 
     const contactId = Number.parseInt(id)
     if (isNaN(contactId)) {
@@ -101,6 +107,9 @@ export async function DELETE(
     if (!authResult.success) {
       return NextResponse.json(authResult, { status: 401 })
     }
+
+    // Ensure database is initialized
+    await db.ensureInitialized()
 
     const contactId = Number.parseInt(id)
     if (isNaN(contactId)) {

--- a/app/api/contacts/route.ts
+++ b/app/api/contacts/route.ts
@@ -13,6 +13,9 @@ export async function GET(request: NextRequest) {
       return NextResponse.json(authResult, { status: 401 })
     }
 
+    // Ensure database is initialized
+    await db.ensureInitialized()
+
     const contacts = await db.listContacts()
     return NextResponse.json({
       success: true,
@@ -39,6 +42,9 @@ export async function POST(request: NextRequest) {
     if (!authResult.success) {
       return NextResponse.json(authResult, { status: 401 })
     }
+
+    // Ensure database is initialized
+    await db.ensureInitialized()
 
     const body = await request.json()
     const contactData = ValidationSchemas.contact(body)

--- a/app/api/devices/[id]/connect/route.ts
+++ b/app/api/devices/[id]/connect/route.ts
@@ -35,6 +35,9 @@ export async function POST(
       )
     }
 
+    // Ensure database is initialized
+    await db.ensureInitialized()
+
     logger.info(`📱 Connecting device ID: ${deviceId}`)
 
     // التحقق من وجود الجهاز

--- a/app/api/devices/[id]/disconnect/route.ts
+++ b/app/api/devices/[id]/disconnect/route.ts
@@ -31,6 +31,9 @@ export async function POST(
       )
     }
 
+    // Ensure database is initialized
+    await db.ensureInitialized()
+
     // التحقق من وجود الجهاز
     const device = await db.getDeviceById(deviceId)
     if (!device) {

--- a/app/api/devices/[id]/route.ts
+++ b/app/api/devices/[id]/route.ts
@@ -31,6 +31,9 @@ export async function GET(
       )
     }
 
+    // Ensure database is initialized
+    await db.ensureInitialized()
+
     // الحصول على معلومات الجهاز
     const device = await db.getDeviceById(deviceId)
     if (!device) {
@@ -100,6 +103,9 @@ export async function PUT(
         { status: 400 },
       )
     }
+
+    // Ensure database is initialized
+    await db.ensureInitialized()
 
     // التحقق من وجود الجهاز
     const existingDevice = await db.getDeviceById(deviceId)
@@ -173,6 +179,9 @@ export async function DELETE(
         { status: 400 },
       )
     }
+
+    // Ensure database is initialized
+    await db.ensureInitialized()
 
     // التحقق من وجود الجهاز
     const device = await db.getDeviceById(deviceId)

--- a/app/api/devices/[id]/schedule/route.ts
+++ b/app/api/devices/[id]/schedule/route.ts
@@ -23,6 +23,9 @@ export async function POST(
       return NextResponse.json({ success: false, error: "معرف الجهاز غير صالح", timestamp: new Date().toISOString() }, { status: 400 })
     }
 
+    // Ensure database is initialized
+    await db.ensureInitialized()
+
     const body = await request.json()
     const data = ValidationSchemas.scheduledMessage(body)
 

--- a/app/api/devices/[id]/send-bulk/route.ts
+++ b/app/api/devices/[id]/send-bulk/route.ts
@@ -31,6 +31,9 @@ export async function POST(
       )
     }
 
+    // Ensure database is initialized
+    await db.ensureInitialized()
+
     // قراءة البيانات
     const body = await request.json()
     const { recipients, message, delay = 1000 } = body

--- a/app/api/devices/[id]/send-media/route.ts
+++ b/app/api/devices/[id]/send-media/route.ts
@@ -23,6 +23,9 @@ export async function POST(
       return NextResponse.json({ success: false, error: "معرف الجهاز غير صالح", timestamp: new Date().toISOString() }, { status: 400 })
     }
 
+    // Ensure database is initialized
+    await db.ensureInitialized()
+
     const body = await request.json()
     const data = ValidationSchemas.mediaMessage(body)
 

--- a/app/api/devices/[id]/send/route.ts
+++ b/app/api/devices/[id]/send/route.ts
@@ -36,6 +36,9 @@ export async function POST(
       )
     }
 
+    // Ensure database is initialized
+    await db.ensureInitialized()
+
     // قراءة البيانات
     const body = await request.json()
     logger.info("📝 Request body:", body)

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -26,6 +26,9 @@ export async function GET(request: NextRequest) {
 
     logger.info("✅ Authentication successful")
 
+    // Ensure database is initialized
+    await db.ensureInitialized()
+
     // جلب المستخدمين من قاعدة البيانات
     const admins = await db.getAllAdmins()
 

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -82,7 +82,7 @@ class DatabaseManager {
   private initialized = false
 
   constructor() {
-    this.init()
+    // Initialization is deferred until ensureInitialized is called
   }
 
   // Expose the underlying Database instance for advanced queries

--- a/tests/lib-websocket-server.test.ts
+++ b/tests/lib-websocket-server.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, expect, jest, test } from '@jest/globals';
 jest.mock('http', () => ({ createServer: jest.fn(() => ({ listen: jest.fn(), close: jest.fn() })) }));
 
 jest.mock('express', () => {
-  const app = { use: jest.fn() };
+  const app = { use: jest.fn(), get: jest.fn(), post: jest.fn() };
   const express = jest.fn(() => app);
   express.json = jest.fn(() => 'jsonMiddleware');
   return express;


### PR DESCRIPTION
## Summary
- delay DB initialization until first use
- ensure DB initialized in API routes
- add compatibility wrappers for auth tests
- improve Express mock in websocket server tests

## Testing
- `npm ci`
- `npm test` *(fails: SqliteError, TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_6847ded73ac48322bd60b461615a60d2