### PR TITLE
Fix tailwind scan paths

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,10 +3,11 @@ import type { Config } from "tailwindcss";
 const config: Config = {
     darkMode: "class",
     content: [
-    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
-    "*.{js,ts,jsx,tsx,mdx}"
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./styles/**/*.{js,ts,jsx,tsx,mdx}",
+    "./lib/**/*.{js,ts,jsx,tsx,mdx}",
+    "./hooks/**/*.{js,ts,jsx,tsx,mdx}"
   ],
   theme: {
         extend: {


### PR DESCRIPTION
## Summary
- refine `content` globs in `tailwind.config.ts` so Tailwind only scans app code

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f7449de08322996814eafc0fd624