### PR TITLE
Fix Tailwind plugin name in postcss config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 }


### PR DESCRIPTION
## Summary
- use `tailwindcss` plugin in `postcss.config.js`

## Testing
- `npm run lint`
- `npm test` *(fails: createMessage inserts a new message, verifyAuth, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6847f74787d88322aeaf51593f3b2928