### PR TITLE
Optimize default admin creation

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -284,14 +284,17 @@ class DatabaseManager {
       const username = ADMIN_USERNAME
       const password = ADMIN_PASSWORD
 
-      const hashedPassword = bcrypt.hashSync(password, 12)
-      this.db
-        .prepare(`INSERT OR IGNORE INTO users (username, password, role) VALUES (?, ?, ?)`)
-        .run(username, hashedPassword, "admin")
       const existingUser = this.db
         .prepare("SELECT id FROM users WHERE username = ?")
         .get(username)
-      if (existingUser) {
+
+      if (!existingUser) {
+        const hashedPassword = bcrypt.hashSync(password, 12)
+        this.db
+          .prepare(`INSERT INTO users (username, password, role) VALUES (?, ?, ?)`)
+          .run(username, hashedPassword, "admin")
+        logger.info(`Default admin user created: ${username}`)
+      } else {
         logger.info(`Default admin user ensured: ${username}`)
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- optimize the admin creation logic by checking for an existing user first

## Testing
- `npm test` *(fails: Test Suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_684806d664088322b94e960bcd9307dd