### PR TITLE
Fix border color compile error

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -102,7 +102,7 @@
 
 @layer base {
   * {
-    @apply border-border;
+    border-color: hsl(var(--border));
   }
   body {
     @apply bg-background text-foreground;


### PR DESCRIPTION
## Summary
- fix tailwind border compile issue by using CSS property

## Testing
- `npm run lint`
- `npm test` *(fails: createMessage inserts a new message, generateAuthToken creates verifiable token, authenticateUser success without database, verifyAuth succeeds with valid token, verifyAuth fails with invalid token)*

------
https://chatgpt.com/codex/tasks/task_e_6849a918acf08322bb9d9992282a062e