### PR TITLE
Fix clean function env warnings

### DIFF
--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -589,8 +589,14 @@ clean_system() {
         cd $DEFAULT_PATH
     fi
     
-    # إيقاف النظام
-    docker-compose down
+    # تحديد ملف البيئة لاستخدامه مع Docker Compose لتفادي التحذيرات
+    if [ -f ".env" ]; then
+        docker-compose --env-file .env down
+    elif [ -f ".env.example" ]; then
+        docker-compose --env-file .env.example down
+    else
+        docker-compose down
+    fi
     
     # حذف الصور غير المستخدمة
     docker image prune -af


### PR DESCRIPTION
## Summary
- avoid docker-compose warnings in `clean` by specifying env file if present

## Testing
- `npm test --silent` *(fails: Cannot find module `bcrypt_lib.node`)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849a706fa9883229b3a97dea6677c68