### PR TITLE
Fix layout head usage

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ export const metadata: Metadata = {
   generator: "Next.js",
   keywords: ["WhatsApp", "Manager", "Business", "Communication"],
   authors: [{ name: "WhatsApp Manager Team" }],
+  icons: [{ rel: "icon", url: "/favicon.svg", type: "image/svg+xml" }],
 }
 
 export const viewport = {
@@ -29,9 +30,6 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ar" dir="rtl">
-      <head>
-        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-      </head>
       <body className={tajawal.className}>
         <ClientLayout>{children}</ClientLayout>
       </body>


### PR DESCRIPTION
## Summary
- remove `<head>` element from root layout and use metadata icons

## Testing
- `npm run lint`
- `npm test` *(fails: SqliteError: 9 values for 10 columns)*

------
https://chatgpt.com/codex/tasks/task_e_6849a88a88948322912fe2e1003948fa