### PR TITLE
Fix runtime build step

### DIFF
--- a/start-production.sh
+++ b/start-production.sh
@@ -38,7 +38,7 @@ fi
 
 # تشغيل Next.js
 echo "🌐 تشغيل Next.js..."
-npm run production
+npm start
 
 # إيقاف WebSocket Server عند الخروج
 if [ "$ENABLE_WEBSOCKET" = "true" ]; then


### PR DESCRIPTION
## Summary
- skip rebuilding Next.js during container startup

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'bcrypt_lib.node')*

------
https://chatgpt.com/codex/tasks/task_e_6849b1fbe22883228de3f99f3bcb8c35