### PR TITLE
Fix production domain and WebSocket settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ ENABLE_WEBSOCKET=false
 WEBSOCKET_PORT=3001
 # Default WebSocket URL clients should connect to
 # Include the /ws/socket.io path by default
-NEXT_PUBLIC_WEBSOCKET_URL=ws://localhost:3001/ws/socket.io
+NEXT_PUBLIC_WEBSOCKET_URL=wss://wa-api.developments.world/ws/socket.io
 # Allowed frontend origin used by the WebSocket server
 FRONTEND_URL=
 

--- a/app/messages/page.tsx
+++ b/app/messages/page.tsx
@@ -94,7 +94,7 @@ export default function MessagesPage() {
     const connectWebSocket = () => {
       let wsUrl =
         process.env.NEXT_PUBLIC_WEBSOCKET_URL ||
-        "ws://localhost:3001/ws/socket.io"
+        "wss://wa-api.developments.world/ws/socket.io"
       logger.info("Attempting to connect to WebSocket", { url: wsUrl, attempt: reconnectAttempts.current + 1 })
 
       ws.current = new WebSocket(wsUrl)

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -27,7 +27,7 @@ module.exports = {
         WEBSOCKET_PORT: process.env.WEBSOCKET_PORT || "3001",
         NEXT_PUBLIC_WEBSOCKET_URL:
           process.env.NEXT_PUBLIC_WEBSOCKET_URL ||
-          `ws://localhost:${process.env.WEBSOCKET_PORT || "3001"}/ws/socket.io`,
+          `wss://wa-api.developments.world/ws/socket.io`,
       },
       error_file: "logs/app-error.log",
       out_file: "logs/app-out.log",

--- a/etc/nginx/sites-available/whatsapp-manager.conf
+++ b/etc/nginx/sites-available/whatsapp-manager.conf
@@ -1,12 +1,12 @@
 server {
     listen 80;
-    server_name localhost;
+    server_name wa-api.developments.world;
     return 301 https://$server_name$request_uri;
 }
 
 server {
     listen 443 ssl http2;
-    server_name localhost;
+    server_name wa-api.developments.world;
 
     # شهادات SSL
     ssl_certificate /etc/nginx/ssl/cert.pem;
@@ -66,8 +66,8 @@ server {
     }
 
     # WebSocket
-    location /socket.io/ {
-        proxy_pass http://whatsapp-manager:3001;
+    location /ws/socket.io/ {
+        proxy_pass http://whatsapp-manager:3001/socket.io/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/lib/use-websocket.ts
+++ b/lib/use-websocket.ts
@@ -22,7 +22,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
   const {
     url =
       process.env.NEXT_PUBLIC_WEBSOCKET_URL ||
-      "http://localhost:3001/ws/socket.io",
+      "wss://wa-api.developments.world/ws/socket.io",
     token,
     deviceId,
     autoConnect = true,

--- a/nginx-ssl.conf
+++ b/nginx-ssl.conf
@@ -64,8 +64,8 @@ server {
     }
     
     # WebSocket proxy
-    location /ws {
-        proxy_pass http://whatsapp-manager:3001;
+    location /ws/socket.io/ {
+        proxy_pass http://whatsapp-manager:3001/socket.io/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,7 +14,7 @@ http {
 
     server {
         listen 80;
-        server_name localhost;
+        server_name wa-api.developments.world;
 
         # Security headers
         add_header X-Frame-Options DENY;
@@ -33,8 +33,8 @@ http {
         limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
 
         # WebSocket endpoint
-        location /ws {
-            proxy_pass http://whatsapp_ws;
+        location /ws/socket.io/ {
+            proxy_pass http://whatsapp_ws/socket.io/;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";


### PR DESCRIPTION
## Summary
- update nginx configuration for production hostname and Socket.IO path
- point WebSocket defaults to production domain
- document WebSocket URL in `.env.example`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849bc251e588322bed22d42a275acbc