### PR TITLE
Fix puppeteer chrome instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ The included `.npmrc` also sets `--legacy-peer-deps` to avoid peer-dependency co
 Make sure to copy the file when building Docker images so the flag is honored there.
 The `wa-manager install full` command now copies dotfiles (including `.npmrc`) to `/opt/whatsapp-manager` automatically.
 
+### Installing Chrome for Puppeteer
+
+If you skipped the bundled browser download using `PUPPETEER_SKIP_DOWNLOAD=1` you must install a compatible Chrome/Chromium before connecting devices:
+
+```bash
+npx puppeteer browsers install chrome
+```
+
+Alternatively set `PUPPETEER_EXECUTABLE_PATH` to point to an existing Chrome binary.
+
 ### Production
 
 For a production build you can use Docker:

--- a/start-production.sh
+++ b/start-production.sh
@@ -21,6 +21,20 @@ if [ "$(id -u)" -eq 0 ]; then
     chown -R 1001:1001 data logs
 fi
 
+# تأكد من توفر متصفح Chrome أو Chromium لـ Puppeteer
+if [ -z "$PUPPETEER_EXECUTABLE_PATH" ]; then
+  PUPPETEER_CACHE_DIR=${PUPPETEER_CACHE_DIR:-/app/.cache/puppeteer}
+  export PUPPETEER_CACHE_DIR
+  if [ ! -d "$PUPPETEER_CACHE_DIR" ] || [ -z "$(ls -A "$PUPPETEER_CACHE_DIR" 2>/dev/null)" ]; then
+    echo "🔍 Installing Chromium for Puppeteer..."
+    npx puppeteer browsers install chrome >/dev/null 2>&1
+  fi
+  if [ -z "$PUPPETEER_EXECUTABLE_PATH" ]; then
+    PUPPETEER_EXECUTABLE_PATH=$(npx puppeteer browsers path chrome 2>/dev/null)
+    export PUPPETEER_EXECUTABLE_PATH
+  fi
+fi
+
 # إنشاء قاعدة البيانات إذا لم تكن موجودة
 if [ ! -f "data/whatsapp_manager.db" ]; then
   echo "🗄️ إنشاء قاعدة البيانات..."


### PR DESCRIPTION
## Summary
- document how to install Chrome for puppeteer
- auto install chromium if missing when running `start-production.sh`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c204705c83228f32bb82d10ef149