### PR TITLE
Handle Chrome crashpad error

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ npx puppeteer browsers install chrome
 
 Alternatively set `PUPPETEER_EXECUTABLE_PATH` to point to an existing Chrome binary.
 
+If Chrome fails to start with a message about `chrome_crashpad_handler`,
+ensure the browser is up to date and try launching with the `--disable-crash-reporter`
+flag (already included by default in the application configuration).
+
 ### Production
 
 For a production build you can use Docker:

--- a/lib/whatsapp-client-manager.ts
+++ b/lib/whatsapp-client-manager.ts
@@ -227,6 +227,7 @@ class WhatsAppClientManager extends EventEmitter {
           "--disable-client-side-phishing-detection",
           "--disable-component-update",
           "--disable-domain-reliability",
+          "--disable-crash-reporter",
           "--disable-features=TranslateUI",
           "--disable-translate",
           "--user-agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",


### PR DESCRIPTION
## Summary
- disable Chrome crash reporter when launching puppeteer
- document troubleshooting step for `chrome_crashpad_handler`

## Testing
- `npm test --silent --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6849c5a021f88322a5472d2e74c7d2cc