### PR TITLE
Fix dotenv path for scripts

### DIFF
--- a/scripts/init-database.js
+++ b/scripts/init-database.js
@@ -8,7 +8,8 @@ require('ts-node').register({
 const { logger } = require('../lib/logger.ts');
 
 // Load environment variables from .env so configuration is available
-require('dotenv').config();
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../.env') });
 
 (async () => {
   try {

--- a/server.js
+++ b/server.js
@@ -4,12 +4,12 @@
  * خادم WhatsApp Manager
  */
 
-require("dotenv").config()
+const path = require("path")
+require("dotenv").config({ path: path.join(__dirname, ".env") })
 const express = require("express")
 const next = require("next")
 const http = require("http")
 const WebSocket = require("ws")
-const path = require("path")
 const fs = require("fs")
 const cors = require("cors")
 const compression = require("compression")


### PR DESCRIPTION
## Summary
- load `.env` using absolute path in `server.js`
- load `.env` using absolute path in `scripts/init-database.js`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cb5b2c348322bae2410ad266c4fb