### PR TITLE
Fix Puppeteer crashpad launch error

### DIFF
--- a/lib/whatsapp-client-manager.ts
+++ b/lib/whatsapp-client-manager.ts
@@ -218,6 +218,8 @@ class WhatsAppClientManager extends EventEmitter {
           "--disable-back-forward-cache",
           "--disable-ipc-flooding-protection",
           "--disable-extensions",
+          "--disable-crash-reporter",
+          "--disable-crashpad",
           "--disable-default-apps",
           "--disable-sync",
           "--metrics-recording-only",


### PR DESCRIPTION
## Summary
- disable crashpad in Puppeteer launch options

## Testing
- `npm test` *(fails: bcrypt native module missing)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849cb206a188322b9d788127d6e4b58