### PR TITLE
Fix env precedence for production start

### DIFF
--- a/app/api/socket/status/route.ts
+++ b/app/api/socket/status/route.ts
@@ -6,7 +6,10 @@ import { getDefaultWebSocketUrl } from "@/lib/utils"
 
 export async function GET() {
   try {
-    const isWebSocketEnabled = process.env.ENABLE_WEBSOCKET === "true"
+    const isWebSocketEnabled =
+      (process.env.ENABLE_WEBSOCKET || "")
+        .trim()
+        .toLowerCase() === "true"
     const websocketPort = process.env.WEBSOCKET_PORT || "3001"
     const websocketUrl = process.env.NEXT_PUBLIC_WEBSOCKET_URL || getDefaultWebSocketUrl()
 

--- a/start-production.sh
+++ b/start-production.sh
@@ -4,9 +4,18 @@ echo "🚀 بدء تشغيل WhatsApp Manager في وضع الإنتاج..."
 
 # تحميل المتغيرات من الملف .env إن وجد
 if [ -f .env ]; then
-  set -o allexport
-  . ./.env
-  set +o allexport
+  while IFS='=' read -r key value; do
+    # تخطي الأسطر الفارغة أو المسبوقة بملاحظات
+    if [[ -z "$key" || "$key" =~ ^# ]]; then
+      continue
+    fi
+    # قم بتصدير المتغير فقط إذا لم يكن محددًا مسبقًا
+    # إزالة أي محارف CR قد تتسبب بعدم تطابق القيم
+    value="${value//$'\r'/}"
+    if [ -z "${!key+x}" ]; then
+      export "$key"="${value}"
+    fi
+  done < .env
 fi
 
 if [ -z "$ADMIN_USERNAME" ] || [ -z "$ADMIN_PASSWORD" ] || [ -z "$JWT_SECRET" ]; then


### PR DESCRIPTION
## Summary
- avoid overriding existing env vars in `start-production.sh`
- trim CR characters when loading `.env`
- tolerate whitespace around `ENABLE_WEBSOCKET` in the status route

## Testing
- `npm run lint`
- `CI=true npm test --silent --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_684daa0a48f88322b28a49af2ef62a2c