### PR TITLE
Handle missing Puppeteer browser

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,8 @@ RESTART_POLICY=unless-stopped
 
 # WhatsApp
 WHATSAPP_SERVER_PORT=3002
-PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+# Leave blank to download a bundled Chromium automatically
+PUPPETEER_EXECUTABLE_PATH=
 
 # Logging
 LOG_LEVEL=debug

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ npx puppeteer browsers install chrome
 ```
 
 Alternatively set `PUPPETEER_EXECUTABLE_PATH` to point to an existing Chrome binary.
+If left empty the start script will download a compatible browser automatically.
 
 If Chrome fails to start with a message about `chrome_crashpad_handler`,
 ensure the browser is up to date and try launching with the `--disable-crash-reporter`
@@ -94,6 +95,7 @@ cp .env.example .env
 - `RESTART_POLICY`: سياسة إعادة تشغيل الحاويات عند استخدام Docker.
 - `WHATSAPP_SERVER_PORT`: المنفذ الداخلي لعميل WhatsApp (الافتراضي 3002).
 - `PUPPETEER_EXECUTABLE_PATH`: مسار ملف Chrome/Chromium المستخدم من Puppeteer.
+اتركه فارغاً ليتم تنزيل متصفح مدمج تلقائياً عند التشغيل.
 
 بقية المتغيرات موثقة داخل الملف `.env.example` ويمكن تعديلها حسب الحاجة.
 

--- a/start-production.sh
+++ b/start-production.sh
@@ -31,6 +31,12 @@ if [ "$(id -u)" -eq 0 ]; then
 fi
 
 # تأكد من توفر متصفح Chrome أو Chromium لـ Puppeteer
+if [ -n "$PUPPETEER_EXECUTABLE_PATH" ] && [ ! -x "$PUPPETEER_EXECUTABLE_PATH" ]; then
+  echo "⚠️  Browser not found at $PUPPETEER_EXECUTABLE_PATH"
+  echo "⬇️  Falling back to bundled Chromium"
+  unset PUPPETEER_EXECUTABLE_PATH
+fi
+
 if [ -z "$PUPPETEER_EXECUTABLE_PATH" ]; then
   PUPPETEER_CACHE_DIR=${PUPPETEER_CACHE_DIR:-/app/.cache/puppeteer}
   export PUPPETEER_CACHE_DIR


### PR DESCRIPTION
## Summary
- fallback to bundled Chromium when the configured browser path doesn't exist
- leave `PUPPETEER_EXECUTABLE_PATH` empty by default
- document automatic browser download in README

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install --ignore-scripts`
- `npm test` *(fails: Cannot find module `bcrypt_lib.node`)*

------
https://chatgpt.com/codex/tasks/task_e_684dc6d57a348322898d32bd5c62b1f4