### PR TITLE
Fix build by marking main page as client component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import Link from "next/link"
 import {
   Smartphone,


### PR DESCRIPTION
## Summary
- add "use client" directive to `app/page.tsx` so Framer Motion loads correctly in Next.js app dir

## Testing
- `npm run build`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684dca0df8c4832281397c65d4c9d201