### PR TITLE
Add websocket fallback path in nginx config

### DIFF
--- a/etc/nginx/sites-available/whatsapp-manager.conf
+++ b/etc/nginx/sites-available/whatsapp-manager.conf
@@ -78,6 +78,19 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Fallback for clients using the default Socket.IO path
+    location /socket.io/ {
+        proxy_pass http://whatsapp-manager:3001/socket.io/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # API
     location /api/ {
         proxy_pass http://whatsapp-manager:3000;


### PR DESCRIPTION
## Summary
- update nginx site config to include a `/socket.io/` location fallback so websocket clients using the default path can connect

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684dcd8f8c0883228786cfdaa738ce4b