### PR TITLE
Add configurable Puppeteer args

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,9 @@ RESTART_POLICY=unless-stopped
 WHATSAPP_SERVER_PORT=3002
 # Leave blank to download a bundled Chromium automatically
 PUPPETEER_EXECUTABLE_PATH=
+# Optional extra flags passed to Chromium, comma separated
+# Example: PUPPETEER_ARGS=--disable-crashpad
+PUPPETEER_ARGS=
 
 # Logging
 LOG_LEVEL=debug

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ Alternatively set `PUPPETEER_EXECUTABLE_PATH` to point to an existing Chrome bin
 If left empty the start script will download a compatible browser automatically.
 
 If Chrome fails to start with a message about `chrome_crashpad_handler`,
-ensure the browser is up to date and try launching with the `--disable-crash-reporter`
-flag (already included by default in the application configuration).
+ensure the browser is up to date. If the problem persists you can pass extra
+flags via the `PUPPETEER_ARGS` variable, e.g. `PUPPETEER_ARGS=--disable-crashpad`
+alongside the `--disable-crash-reporter` flag already included by default.
 
 ### Production
 
@@ -96,6 +97,8 @@ cp .env.example .env
 - `WHATSAPP_SERVER_PORT`: المنفذ الداخلي لعميل WhatsApp (الافتراضي 3002).
 - `PUPPETEER_EXECUTABLE_PATH`: مسار ملف Chrome/Chromium المستخدم من Puppeteer.
 اتركه فارغاً ليتم تنزيل متصفح مدمج تلقائياً عند التشغيل.
+- `PUPPETEER_ARGS`: قائمة اختيارات إضافية لـ Chromium مفصولة بفواصل. يمكن
+استخدامها لحل مشاكل التشغيل على بعض الأنظمة كتعطيل Crashpad مثلاً.
 
 بقية المتغيرات موثقة داخل الملف `.env.example` ويمكن تعديلها حسب الحاجة.
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -37,6 +37,7 @@ export const AUTO_CONNECT_DEVICES = process.env.AUTO_CONNECT_DEVICES === "true"
 // إعدادات WhatsApp
 export const WHATSAPP_SERVER_PORT = Number.parseInt(process.env.WHATSAPP_SERVER_PORT || "3002")
 export const PUPPETEER_EXECUTABLE_PATH = process.env.PUPPETEER_EXECUTABLE_PATH
+export const PUPPETEER_ARGS = process.env.PUPPETEER_ARGS
 
 // إعدادات السجلات
 export const LOG_LEVEL = process.env.LOG_LEVEL || "debug"

--- a/lib/whatsapp-client-manager.ts
+++ b/lib/whatsapp-client-manager.ts
@@ -8,6 +8,7 @@ import fs from "fs";
 import { EventEmitter } from "events";
 import {
   PUPPETEER_EXECUTABLE_PATH,
+  PUPPETEER_ARGS,
   ENABLE_WEBSOCKET,
   AUTO_CONNECT_DEVICES,
 } from "./config";
@@ -237,6 +238,11 @@ class WhatsAppClientManager extends EventEmitter {
         ],
         timeout: 60000,
       };
+
+      if (PUPPETEER_ARGS) {
+        const extraArgs = PUPPETEER_ARGS.split(',').map((a) => a.trim()).filter(Boolean);
+        puppeteerOptions.args.push(...extraArgs);
+      }
 
       if (PUPPETEER_EXECUTABLE_PATH) {
         puppeteerOptions.executablePath = PUPPETEER_EXECUTABLE_PATH;


### PR DESCRIPTION
## Summary
- allow passing custom Chromium flags via `PUPPETEER_ARGS`
- document new variable in `.env.example` and README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dd0a4749483229559a8e27fe682eb