### PR TITLE
Adjust theme contrast colors

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -182,8 +182,8 @@ body {
   }
 
   .status-connecting {
-    background-color: rgb(59 130 246); /* tailwind blue-500 */
-    color: white;
+    background-color: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
     animation: pulse 2s infinite;
   }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -83,7 +83,7 @@
     --success: 142 70% 45%;
     --success-foreground: 144.9 80.4% 10%;
     --warning: 38 92% 50%;
-    --warning-foreground: 48 96% 89%;
+    --warning-foreground: 222 47% 11%;
     --error: 0 62.8% 30.6%;
     --error-foreground: 210 40% 98%;
     --chart-1: 214 83% 62%;


### PR DESCRIPTION
## Summary
- improve dark warning foreground to keep contrast
- set `.status-connecting` colors using theme variables for better contrast

## Testing
- `npm test` *(fails: Cannot find module bcrypt)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684dd37f12588322ab5cc56e995c5d4f