### PR TITLE
Improve mobile responsive layout

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -163,7 +163,7 @@ export default function DashboardPage() {
         )}
 
         {/* إحصائيات سريعة */}
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">إجمالي الأجهزة</CardTitle>
@@ -216,7 +216,7 @@ export default function DashboardPage() {
             <CardDescription>حالة النظام والخدمات</CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="grid gap-4 md:grid-cols-2">
+            <div className="grid gap-4 sm:grid-cols-2">
               <div>
                 <h3 className="font-medium mb-2">مدة التشغيل</h3>
                 <p className="text-2xl font-bold text-green-600">{stats.system.uptime}</p>

--- a/components/layout/dashboard-layout.tsx
+++ b/components/layout/dashboard-layout.tsx
@@ -14,7 +14,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
       <Header onMenuClick={() => {}} />
       <div className="flex">
         <Sidebar />
-        <main className="flex-1 p-6 lg:pr-80">
+        <main className="flex-1 p-4 sm:p-6 lg:pr-80">
           <div className="mx-auto max-w-7xl">{children}</div>
         </main>
       </div>

--- a/components/layout/main-layout.tsx
+++ b/components/layout/main-layout.tsx
@@ -90,7 +90,7 @@ export function MainLayout({ children }: MainLayoutProps) {
         {/* Sidebar */}
         <aside
           className={cn(
-            "fixed inset-y-0 left-0 z-50 w-64 bg-white dark:bg-gray-800 shadow-lg transform transition-transform duration-200 ease-in-out lg:translate-x-0 lg:static lg:inset-0",
+            "fixed inset-y-0 left-0 z-50 w-64 sm:w-72 md:w-80 bg-white dark:bg-gray-800 shadow-lg transform transition-transform duration-200 ease-in-out lg:translate-x-0 lg:static lg:inset-0",
             sidebarOpen ? "translate-x-0" : "-translate-x-full",
           )}
         >
@@ -136,7 +136,7 @@ export function MainLayout({ children }: MainLayoutProps) {
 
         {/* Main content */}
         <main className="flex-1 lg:ml-0">
-          <div className="p-6">{children}</div>
+          <div className="p-4 sm:p-6 md:p-8">{children}</div>
         </main>
       </div>
 

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -113,10 +113,10 @@ export function Sidebar({ onClose }: SidebarProps) {
       animate={{ x: 0 }}
       exit={{ x: "100%" }}
       transition={{ type: "spring", damping: 30, stiffness: 300 }}
-      className="flex h-full w-72 flex-col bg-white/80 backdrop-blur-xl border-l border-gray-200/50 dark:bg-gray-900/80 dark:border-gray-700/50 shadow-2xl"
+      className="flex h-full w-64 sm:w-72 md:w-80 flex-col bg-white/80 backdrop-blur-xl border-l border-gray-200/50 dark:bg-gray-900/80 dark:border-gray-700/50 shadow-2xl"
     >
       {/* Header */}
-      <div className="flex h-16 items-center justify-between px-6 border-b border-gray-200/50 dark:border-gray-700/50">
+      <div className="flex h-16 items-center justify-between px-4 sm:px-6 border-b border-gray-200/50 dark:border-gray-700/50">
         <div className="flex items-center gap-3">
           <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center">
             <Zap className="h-4 w-4 text-white" />
@@ -136,7 +136,7 @@ export function Sidebar({ onClose }: SidebarProps) {
       </div>
 
       {/* Navigation */}
-      <nav className="flex-1 space-y-2 p-4">
+      <nav className="flex-1 space-y-2 p-4 sm:p-6">
         <div className="space-y-1">
           {navigation.map((item) => {
             const isActive = pathname === item.href
@@ -246,7 +246,7 @@ export function Sidebar({ onClose }: SidebarProps) {
           <h3 className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider px-3">
             إجراءات سريعة
           </h3>
-          <div className="grid grid-cols-1 gap-2">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
             {quickActions.map((action) => {
               const Icon = action.icon
               return (
@@ -268,7 +268,7 @@ export function Sidebar({ onClose }: SidebarProps) {
       </nav>
 
       {/* Footer */}
-      <div className="border-t border-gray-200/50 dark:border-gray-700/50 p-4">
+      <div className="border-t border-gray-200/50 dark:border-gray-700/50 p-4 sm:p-6">
         <div className="flex items-center gap-3 rounded-lg bg-gradient-to-r from-blue-50 to-purple-50 dark:from-blue-900/20 dark:to-purple-900/20 p-3">
           <div className="h-8 w-8 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center">
             <Shield className="h-4 w-4 text-white" />


### PR DESCRIPTION
## Summary
- add breakpoints for stats and system info grids
- tweak sidebar widths and paddings
- adjust dashboard layout spacing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684dd37a8e74832295d648d95d0e923d