### PR TITLE
Add location messaging

### DIFF
--- a/app/api/devices/[id]/send-location/route.ts
+++ b/app/api/devices/[id]/send-location/route.ts
@@ -1,0 +1,85 @@
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+import { type NextRequest, NextResponse } from "next/server"
+import { whatsappManager } from "@/lib/whatsapp-client-manager"
+import { db } from "@/lib/database"
+import { verifyAuth } from "@/lib/auth"
+import { ValidationSchemas } from "@/lib/validation"
+import { logger } from "@/lib/logger"
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  try {
+    const authResult = await verifyAuth(request)
+    if (!authResult.success) {
+      return NextResponse.json(authResult, { status: 401 })
+    }
+
+    const deviceId = Number.parseInt(id)
+    if (isNaN(deviceId)) {
+      return NextResponse.json(
+        { success: false, error: "معرف الجهاز غير صالح", timestamp: new Date().toISOString() },
+        { status: 400 },
+      )
+    }
+
+    await db.ensureInitialized()
+
+    const body = await request.json()
+    const data = ValidationSchemas.locationMessage(body)
+
+    if (!data) {
+      return NextResponse.json(
+        { success: false, error: "بيانات غير صالحة", timestamp: new Date().toISOString() },
+        { status: 400 },
+      )
+    }
+
+    const device = await db.getDeviceById(deviceId)
+    if (!device) {
+      return NextResponse.json(
+        { success: false, error: "الجهاز غير موجود", timestamp: new Date().toISOString() },
+        { status: 404 },
+      )
+    }
+
+    if (!whatsappManager.isClientReady(deviceId)) {
+      return NextResponse.json(
+        { success: false, error: "الجهاز غير متصل", timestamp: new Date().toISOString() },
+        { status: 400 },
+      )
+    }
+
+    const success = await whatsappManager.sendLocationMessage(
+      deviceId,
+      data.recipient,
+      data.latitude,
+      data.longitude,
+      data.description,
+    )
+
+    if (success) {
+      return NextResponse.json({ success: true, message: "تم الإرسال", timestamp: new Date().toISOString() })
+    }
+
+    return NextResponse.json(
+      { success: false, error: "فشل الإرسال", timestamp: new Date().toISOString() },
+      { status: 500 },
+    )
+  } catch (error) {
+    logger.error("Error sending location message:", error)
+    return NextResponse.json(
+      {
+        success: false,
+        error: "خطأ في الخادم",
+        details: error instanceof Error ? error.message : "Unknown",
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    )
+  }
+}

--- a/app/devices/page.tsx
+++ b/app/devices/page.tsx
@@ -254,6 +254,9 @@ export default function DevicesPage() {
     isBulk: boolean
     file?: File | null
     scheduledAt?: string
+    latitude?: number
+    longitude?: number
+    isLocation?: boolean
   }) => {
     try {
       let url = data.isBulk
@@ -262,6 +265,8 @@ export default function DevicesPage() {
 
       if (data.file) {
         url = `/api/devices/${data.deviceId}/send-media`
+      } else if (data.isLocation) {
+        url = `/api/devices/${data.deviceId}/send-location`
       } else if (data.scheduledAt) {
         url = `/api/devices/${data.deviceId}/schedule`
       }
@@ -273,6 +278,13 @@ export default function DevicesPage() {
           data: await fileToBase64(data.file),
           mimeType: data.file.type,
           caption: data.message,
+        }
+      } else if (data.isLocation) {
+        payload = {
+          recipient: data.recipient,
+          latitude: data.latitude,
+          longitude: data.longitude,
+          description: data.message,
         }
       } else if (data.scheduledAt) {
         payload = { recipient: data.recipient, message: data.message, sendAt: data.scheduledAt }

--- a/app/messages/page.tsx
+++ b/app/messages/page.tsx
@@ -212,6 +212,9 @@ export default function MessagesPage() {
     isBulk: boolean
     file?: File | null
     scheduledAt?: string
+    latitude?: number
+    longitude?: number
+    isLocation?: boolean
   }) => {
     try {
       let url = data.isBulk
@@ -220,6 +223,8 @@ export default function MessagesPage() {
 
       if (data.file) {
         url = `/api/devices/${data.deviceId}/send-media`
+      } else if (data.isLocation) {
+        url = `/api/devices/${data.deviceId}/send-location`
       } else if (data.scheduledAt) {
         url = `/api/devices/${data.deviceId}/schedule`
       }
@@ -231,6 +236,13 @@ export default function MessagesPage() {
           data: await fileToBase64(data.file),
           mimeType: data.file.type,
           caption: data.message,
+        }
+      } else if (data.isLocation) {
+        payload = {
+          recipient: data.recipient,
+          latitude: data.latitude,
+          longitude: data.longitude,
+          description: data.message,
         }
       } else if (data.scheduledAt) {
         payload = { recipient: data.recipient, message: data.message, sendAt: data.scheduledAt }

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -32,6 +32,13 @@ const scheduledMessageSchema = z.object({
   sendAt: z.string(),
 })
 
+const locationMessageSchema = z.object({
+  recipient: z.string().min(10, "رقم المستقبل مطلوب"),
+  latitude: z.number(),
+  longitude: z.number(),
+  description: z.string().optional().default(""),
+})
+
 // Bulk message validation schema
 const bulkMessageSchema = z.object({
   recipients: z.array(z.string()).min(1, "قائمة المستقبلين مطلوبة"),
@@ -91,6 +98,15 @@ export const ValidationSchemas = {
     }
   },
 
+  locationMessage: (data: any) => {
+    try {
+      return locationMessageSchema.parse(data)
+    } catch (error) {
+      logger.error("Location message validation error:", error as Error)
+      return null
+    }
+  },
+
   bulkMessage: (data: any) => {
     try {
       return bulkMessageSchema.parse(data)
@@ -119,4 +135,5 @@ export {
   userSchema,
   mediaMessageSchema,
   scheduledMessageSchema,
+  locationMessageSchema,
 }


### PR DESCRIPTION
## Summary
- create send-location API route
- validate location messages
- add location tab to message dialog
- support location messages in pages

## Testing
- `npm run lint`
- `npx jest` *(fails: Home Page test)*

------
https://chatgpt.com/codex/tasks/task_e_684dd533b7208322abfa7443843af769