### PR TITLE
Fix bulk message type safety

### DIFF
--- a/app/devices/page.tsx
+++ b/app/devices/page.tsx
@@ -257,7 +257,8 @@ export default function DevicesPage() {
       | { deviceId: number; formData: FormData; isMedia: true },
   ) => {
     try {
-      let url = data.isBulk
+      const isBulk = "isBulk" in data && data.isBulk
+      let url = isBulk
         ? `/api/devices/${data.deviceId}/send-bulk`
         : `/api/devices/${data.deviceId}/send`
 
@@ -303,7 +304,7 @@ export default function DevicesPage() {
           }
         } else if (data.scheduledAt) {
           payload = { recipient: data.recipient, message: data.message, sendAt: data.scheduledAt }
-        } else if (data.isBulk) {
+        } else if (isBulk) {
           payload = { recipients: data.recipients, message: data.message }
         } else {
           payload = { recipient: data.recipient, message: data.message }

--- a/app/messages/page.tsx
+++ b/app/messages/page.tsx
@@ -216,7 +216,8 @@ export default function MessagesPage() {
       | { deviceId: number; formData: FormData; isMedia: true },
   ) => {
     try {
-      let url = data.isBulk
+      const isBulk = "isBulk" in data && data.isBulk
+      let url = isBulk
         ? `/api/devices/${data.deviceId}/send-bulk`
         : `/api/devices/${data.deviceId}/send`
 
@@ -262,7 +263,7 @@ export default function MessagesPage() {
           }
         } else if (data.scheduledAt) {
           payload = { recipient: data.recipient, message: data.message, sendAt: data.scheduledAt }
-        } else if (data.isBulk) {
+        } else if (isBulk) {
           payload = { recipients: data.recipients, message: data.message }
         } else {
           payload = { recipient: data.recipient, message: data.message }


### PR DESCRIPTION
## Summary
- use `isBulk` variable for safer type narrowing in message senders

## Testing
- `npm run build` *(fails: Failed to initialize database - cannot find bcrypt bindings)*
- `npm run lint`
- `npm test` *(fails: cannot find bcrypt bindings)*

------
https://chatgpt.com/codex/tasks/task_e_684de44c09748322a584b1c86111faf8