### PR TITLE
Check websocket build before startup

### DIFF
--- a/start-production.sh
+++ b/start-production.sh
@@ -63,6 +63,10 @@ fi
 
 # تشغيل WebSocket Server
 if [ "$ENABLE_WEBSOCKET" = "true" ]; then
+  if [ ! -f ./dist/websocket-server.js ]; then
+    echo "❌ dist/websocket-server.js غير موجود. تأكد من تشغيل 'npm run build:ws' أثناء بناء الصورة" >&2
+    exit 1
+  fi
   echo "📡 تشغيل WebSocket Server..."
   node ./dist/websocket-server.js &
   WS_PID=$!


### PR DESCRIPTION
## Summary
- ensure start-production.sh verifies websocket server build exists

## Testing
- `npm ci`
- `npx jest --runInBand` *(fails: TestingLibraryElementError)*

------
https://chatgpt.com/codex/tasks/task_e_684de86c6354832294384220b086f070