### PR TITLE
Fix missing WebSocket build

### DIFF
--- a/start-production.sh
+++ b/start-production.sh
@@ -67,8 +67,14 @@ fi
 # تشغيل WebSocket Server
 if [ "$ENABLE_WEBSOCKET" = "true" ]; then
   if [ ! -f ./dist/websocket-server.js ]; then
-    echo "❌ dist/websocket-server.js غير موجود. تأكد من تشغيل 'npm run build:ws' أثناء بناء الصورة" >&2
-    exit 1
+    echo "⚠️  dist/websocket-server.js غير موجود. سيتم محاولة إنشائه..." >&2
+    npm run build:ws >/tmp/build_ws.log 2>&1
+    status=$?
+    if [ $status -ne 0 ] || [ ! -f ./dist/websocket-server.js ]; then
+      echo "❌ فشل إنشاء dist/websocket-server.js" >&2
+      cat /tmp/build_ws.log >&2
+      exit 1
+    fi
   fi
   echo "📡 تشغيل WebSocket Server..."
   node ./dist/websocket-server.js &


### PR DESCRIPTION
## Summary
- build websocket server automatically at runtime if missing

## Testing
- `npm test` *(fails: Home Page test in tests/app.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_684df2c36dfc8322ae0dc86c548e8a79