### PR TITLE
Improve websocket startup error handling

### DIFF
--- a/start-production.sh
+++ b/start-production.sh
@@ -66,12 +66,13 @@ if [ "$ENABLE_WEBSOCKET" = "true" ]; then
     fi
   fi
   echo "📡 تشغيل WebSocket Server..."
-  node ./dist/websocket-server.js &
+  node ./dist/websocket-server.js >logs/websocket.log 2>&1 &
   WS_PID=$!
   echo "WebSocket Server PID: $WS_PID"
   sleep 1
   if ! kill -0 "$WS_PID" 2>/dev/null; then
-    echo "❌ تعذر تشغيل WebSocket Server" >&2
+    echo "❌ تعذر تشغيل WebSocket Server"
+    tail -n 20 logs/websocket.log
     exit 1
   fi
   trap 'echo "📡 إيقاف WebSocket Server..."; kill $WS_PID' EXIT


### PR DESCRIPTION
## Summary
- capture websocket server output in `logs/websocket.log`
- print the last few log lines when startup fails

## Testing
- `npm test` *(fails: FAIL tests/app.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_684dfcf788688322bbdd079e4e6976c6