### PR TITLE
Make restart policy configurable

### DIFF
--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -370,7 +370,7 @@ services:
     build: .
     image: whatsapp-manager:latest
     container_name: whatsapp-manager
-    restart: unless-stopped
+    restart: \${RESTART_POLICY:-unless-stopped}
     ports:
       - "127.0.0.1:3000:3000"
       - "127.0.0.1:3001:3001"
@@ -404,7 +404,7 @@ services:
   nginx:
     image: nginx:alpine
     container_name: whatsapp-manager-nginx
-    restart: unless-stopped
+    restart: \${RESTART_POLICY:-unless-stopped}
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
## Summary
- replace hardcoded restart policy in docker compose with `${RESTART_POLICY:-unless-stopped}` in `wa-manager.sh`

## Testing
- `npm run lint`
- `npx jest --runInBand --ci` *(fails: Home Page tests)*

------
https://chatgpt.com/codex/tasks/task_e_684dfdd76d088322a9573ef60c47a56f