### PR TITLE
Update env regeneration in update_system

### DIFF
--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -904,7 +904,11 @@ update_system() {
 
     # إعادة إنشاء المفاتيح المفقودة في .env
     echo -e "${YELLOW}⏳ التحقق من ملف .env وإنشاء المفاتيح الناقصة...${NC}"
-    node scripts/generate-env.js
+    if npm run --silent setup >/dev/null 2>&1; then
+        npm run setup
+    else
+        node scripts/generate-env.js
+    fi
 
     # إعادة بناء الصور
     echo -e "${YELLOW}⏳ إعادة بناء الصور...${NC}"


### PR DESCRIPTION
## Summary
- ensure `wa-manager.sh` regenerates `.env` keys after pulling updates

## Testing
- `npm test --silent` *(fails: app.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_684dff36716483229b9d038b8b70db77