### PR TITLE
Add test for generate-env script

### DIFF
--- a/tests/generate-env.test.ts
+++ b/tests/generate-env.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFileSync } from 'child_process';
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function runGenerateEnv(cwd: string) {
+  const scriptPath = path.join(repoRoot, 'scripts', 'generate-env.js');
+  execFileSync('node', [scriptPath], { cwd });
+}
+
+test('generate-env creates .env with new JWT_SECRET', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'env-test-'));
+  const exampleSource = path.join(repoRoot, '.env.example');
+  const exampleDest = path.join(tmpDir, '.env.example');
+
+  fs.copyFileSync(exampleSource, exampleDest);
+
+  runGenerateEnv(tmpDir);
+
+  const envPath = path.join(tmpDir, '.env');
+  expect(fs.existsSync(envPath)).toBe(true);
+
+  const exampleContent = fs.readFileSync(exampleSource, 'utf8');
+  const exampleSecret = /^JWT_SECRET=(.*)$/m.exec(exampleContent)?.[1];
+  const envContent = fs.readFileSync(envPath, 'utf8');
+  const secret = /^JWT_SECRET=(.*)$/m.exec(envContent)?.[1];
+
+  expect(secret).toBeDefined();
+  expect(secret).not.toBe(exampleSecret);
+});


### PR DESCRIPTION
## Summary
- create a Jest test to ensure generate-env creates a new JWT secret

## Testing
- `./node_modules/.bin/jest --runInBand --testPathPattern tests/generate-env.test.ts`
- `./node_modules/.bin/jest --runInBand --ci --colors=false tests/app.test.tsx tests/generate-env.test.ts` *(fails: tests/app.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_684dfdd31580832285bcc8a07558567e