### PR TITLE
Add dotenv initialization in WebSocket server

### DIFF
--- a/lib/websocket-server.ts
+++ b/lib/websocket-server.ts
@@ -6,6 +6,10 @@ import helmet from "helmet"
 import compression from "compression"
 import jwt from "jsonwebtoken"
 import { logger } from "./logger"
+import path from "path"
+import dotenv from "dotenv"
+
+dotenv.config({ path: path.join(__dirname, "../.env") })
 import { JWT_SECRET } from "./config"
 
 // إعدادات البيئة


### PR DESCRIPTION
## Summary
- load `.env` variables before importing config in the WebSocket server
- rebuild websocket server

## Testing
- `npx jest --runInBand tests/app.test.tsx` *(fails: TestingLibraryElementError)*

------
https://chatgpt.com/codex/tasks/task_e_684e061601708322b6ecd158f492e1d3