### PR TITLE
Update pm2 websocket startup

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -43,7 +43,8 @@ module.exports = {
     },
     {
       name: "whatsapp-manager-websocket",
-      script: "dist/websocket-server.js",
+      script: "npm",
+      args: "run ws:prod",
       cwd: process.cwd(),
       instances: 1,
       exec_mode: "fork",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:ci": "npm ci && npm test",
     "ws": "ts-node -P tsconfig.ws.json lib/websocket-server.ts",
     "build:ws": "tsc -p tsconfig.ws.json",
+    "prews:prod": "npm run build:ws",
     "ws:prod": "node dist/websocket-server.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add prews:prod script so websocket server builds automatically
- update pm2 config to use `npm run ws:prod`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0949919083228d56cc45b2a6982d