### PR TITLE
Update docker-compose env setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ version: '3.8'
 services:
   whatsapp-manager:
     build: .
+    env_file:
+      - .env
     image: whatsapp-manager:latest
     container_name: whatsapp-manager
     restart: ${RESTART_POLICY:-unless-stopped}
@@ -15,15 +17,6 @@ services:
 #      Replace default credentials before using in production
       - NODE_ENV=production
       - DATABASE_PATH=/app/data/whatsapp_manager.db
-      - ADMIN_USERNAME=${ADMIN_USERNAME}
-      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
-      - JWT_SECRET=${JWT_SECRET}
-      - MAX_AUTH_ATTEMPTS=${MAX_AUTH_ATTEMPTS:-5}
-      - JWT_EXPIRES_IN=${JWT_EXPIRES_IN:-24h}
-      - ENABLE_WEBSOCKET=${ENABLE_WEBSOCKET:-true}
-      - WEBSOCKET_PORT=${WEBSOCKET_PORT:-3001}
-      - NEXT_PUBLIC_WEBSOCKET_URL=${NEXT_PUBLIC_WEBSOCKET_URL:-ws://localhost:${WEBSOCKET_PORT:-3001}/ws/socket.io}
-      - LOG_LEVEL=${LOG_LEVEL:-debug}
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs


### PR DESCRIPTION
## Summary
- configure `whatsapp-manager` service to load variables from `.env`
- keep only `NODE_ENV` and `DATABASE_PATH` overrides

## Testing
- `npm test` *(fails: Cannot find module '/workspace/whatsapp-manager/node_modules/bcrypt/lib/binding/napi-v3/bcrypt_lib.node')*

------
https://chatgpt.com/codex/tasks/task_e_684e0617c6808322b022617c3431db14