### PR TITLE
Add websocket port availability check

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ npx puppeteer browsers install chrome
 docker-compose up --build -d
 ```
 يُشغِّل هذا الأمر حاوية التطبيق مع Nginx ويتولى السكربت `start-production.sh` ضبط البيئة وبدء خادم WebSocket افتراضيًا. يمكن إيقاف البث الفوري بوضع `ENABLE_WEBSOCKET=false` في ملف البيئة.
+يجب التأكد من أن المنفذ المحدد في `WEBSOCKET_PORT` غير مشغول قبل التشغيل وإلا سيتوقف السكربت عن العمل.
 
 ## إعداد متغيرات البيئة
 انسخ الملف الافتراضي ثم غيِّر القيم الحساسة قبل التشغيل:
@@ -58,7 +59,7 @@ cp .env.example .env
 - `ADMIN_USERNAME` و`ADMIN_PASSWORD`: بيانات الدخول للوحة التحكم.
 - `JWT_SECRET`: مفتاح توقيع التوكنات.
 - `DATABASE_PATH`: مسار قاعدة البيانات.
-- `ENABLE_WEBSOCKET` و`WEBSOCKET_PORT`: تشغيل خادم WebSocket وتحديد المنفذ.
+- `ENABLE_WEBSOCKET` و`WEBSOCKET_PORT`: تشغيل خادم WebSocket وتحديد المنفذ. يجب أن يكون هذا المنفذ متاحًا وغير مستخدم قبل التشغيل.
 - بقية المتغيرات موثقة داخل `.env.example` ويمكن تعديلها حسب الحاجة.
 
 بعد ضبط الملف يمكن تشغيل:

--- a/start-production.sh
+++ b/start-production.sh
@@ -68,6 +68,10 @@ if [ "$ENABLE_WEBSOCKET" = "true" ]; then
     fi
   fi
   echo "📡 تشغيل WebSocket Server..."
+  if lsof -i:"$WEBSOCKET_PORT" >/dev/null 2>&1 || ss -ltn | grep -q ":$WEBSOCKET_PORT\\b"; then
+    echo "❌ Port $WEBSOCKET_PORT already in use" >&2
+    exit 1
+  fi
   node ./dist/websocket-server.js >logs/websocket.log 2>&1 &
   WS_PID=$!
   echo "WebSocket Server PID: $WS_PID"


### PR DESCRIPTION
## Summary
- ensure `start-production.sh` fails early when the WebSocket port is occupied
- document the requirement for `WEBSOCKET_PORT` to be free before starting Docker

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0d1d683c83229d94072491017560