### PR TITLE
Add entrypoint to websocket server

### DIFF
--- a/lib/websocket-server.ts
+++ b/lib/websocket-server.ts
@@ -457,3 +457,8 @@ const websocketServerApi = {
 }
 
 export default websocketServerApi
+
+// إذا تم تشغيل الملف مباشرةً، قم ببدء خادم WebSocket
+if (require.main === module) {
+  initializeWebSocketServer()
+}


### PR DESCRIPTION
## Summary
- add runtime check so websocket server can run standalone
- compile websocket server

## Testing
- `npm run build:ws`
- `node dist/websocket-server.js` *(fails: Error: Environment variable JWT_SECRET is required)*
- `node dist/websocket-server.js` after copying .env example
- `./wa-manager.sh start` *(fails: Docker Compose غير مثبت)*
- `./wa-manager.sh logs` *(fails: docker-compose: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0eae1c108322b0033a8ed99b480a