### PR TITLE
Add WebSocket port check

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npx puppeteer browsers install chrome
 docker-compose up --build -d
 ```
 يُشغِّل هذا الأمر حاوية التطبيق مع Nginx ويتولى السكربت `start-production.sh` ضبط البيئة وبدء خادم WebSocket افتراضيًا. يمكن إيقاف البث الفوري بوضع `ENABLE_WEBSOCKET=false` في ملف البيئة.
-يجب التأكد من أن المنفذ المحدد في `WEBSOCKET_PORT` غير مشغول قبل التشغيل وإلا سيتوقف السكربت عن العمل.
+يجب التأكد من أن المنفذ المحدد في `WEBSOCKET_PORT` غير مشغول قبل التشغيل وإلا سيتوقف السكربت عن العمل برسالة "Port $WEBSOCKET_PORT already in use".
 
 ## إعداد متغيرات البيئة
 انسخ الملف الافتراضي ثم غيِّر القيم الحساسة قبل التشغيل:
@@ -59,8 +59,7 @@ cp .env.example .env
 - `ADMIN_USERNAME` و`ADMIN_PASSWORD`: بيانات الدخول للوحة التحكم.
 - `JWT_SECRET`: مفتاح توقيع التوكنات.
 - `DATABASE_PATH`: مسار قاعدة البيانات.
-- `ENABLE_WEBSOCKET` و`WEBSOCKET_PORT`: تشغيل خادم WebSocket وتحديد المنفذ. يجب أن يكون هذا المنفذ متاحًا وغير مستخدم قبل التشغيل.
-- بقية المتغيرات موثقة داخل `.env.example` ويمكن تعديلها حسب الحاجة.
+- `ENABLE_WEBSOCKET` و`WEBSOCKET_PORT`: تشغيل خادم WebSocket وتحديد المنفذ. يجب أن يكون هذا المنفذ متاحًا وغير مستخدم قبل التشغيل، وإلا سيُظهر السكربت الخطأ "Port $WEBSOCKET_PORT already in use" ثم يتوقف.
 
 بعد ضبط الملف يمكن تشغيل:
 ```bash

--- a/start-production.sh
+++ b/start-production.sh
@@ -24,6 +24,15 @@ if [ "$(id -u)" -eq 0 ]; then
     chown -R 1001:1001 data logs
 fi
 
+# دالة للتحقق من أن المنفذ متاح قبل التشغيل
+is_port_free() {
+  if lsof -i:"$1" >/dev/null 2>&1 || ss -ltn | grep -q ":$1\\b"; then
+    return 1
+  else
+    return 0
+  fi
+}
+
 # تأكد من توفر متصفح Chrome أو Chromium لـ Puppeteer
 if [ -n "$PUPPETEER_EXECUTABLE_PATH" ] && [ ! -x "$PUPPETEER_EXECUTABLE_PATH" ]; then
   echo "⚠️  Browser not found at $PUPPETEER_EXECUTABLE_PATH"
@@ -68,7 +77,7 @@ if [ "$ENABLE_WEBSOCKET" = "true" ]; then
     fi
   fi
   echo "📡 تشغيل WebSocket Server..."
-  if lsof -i:"$WEBSOCKET_PORT" >/dev/null 2>&1 || ss -ltn | grep -q ":$WEBSOCKET_PORT\\b"; then
+  if ! is_port_free "$WEBSOCKET_PORT"; then
     echo "❌ Port $WEBSOCKET_PORT already in use" >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary
- check WebSocket port availability in `start-production.sh`
- explain the port check in the README

## Testing
- `npm test` *(fails: bcrypt native module missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e1005ddac83228e47e2b758d28c43