### PR TITLE
Fix Docker build by copying tsconfig.ws.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /app
 
 # Copy package manifests first for better Docker layer caching
-COPY package.json package-lock.json .npmrc ./
+COPY package.json package-lock.json .npmrc tsconfig.ws.json ./
 
 # Install dependencies with development packages enabled
 ENV NODE_ENV=development


### PR DESCRIPTION
## Summary
- include `tsconfig.ws.json` before running `npm ci`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e15e347548322b2c081f81bffab85