### PR TITLE
Fix websocket health check URL

### DIFF
--- a/app/api/socket/status/route.ts
+++ b/app/api/socket/status/route.ts
@@ -12,6 +12,18 @@ export async function GET() {
         .toLowerCase() === "true"
     const websocketPort = process.env.WEBSOCKET_PORT || "3001"
     const websocketUrl = process.env.NEXT_PUBLIC_WEBSOCKET_URL || getDefaultWebSocketUrl()
+    let healthUrl: string
+    if (process.env.NEXT_PUBLIC_WEBSOCKET_URL) {
+      try {
+        const parsed = new URL(process.env.NEXT_PUBLIC_WEBSOCKET_URL)
+        const protocol = parsed.protocol.startsWith("wss") ? "https" : "http"
+        healthUrl = `${protocol}://${parsed.host}/health`
+      } catch {
+        healthUrl = `http://localhost:${websocketPort}/health`
+      }
+    } else {
+      healthUrl = `http://localhost:${websocketPort}/health`
+    }
 
     if (!isWebSocketEnabled) {
       return NextResponse.json({
@@ -29,7 +41,7 @@ export async function GET() {
 
     // محاولة التحقق من حالة خادم WebSocket عبر طلب صحة HTTP
     try {
-      const healthResponse = await fetch(`http://localhost:${websocketPort}/health`)
+      const healthResponse = await fetch(healthUrl)
 
       if (!healthResponse.ok) {
         const text = await healthResponse.text()

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -146,6 +146,7 @@ test('GET /api/devices returns devices array', async () => {
 test('GET /api/socket/status reports running when health check succeeds', async () => {
   process.env.ENABLE_WEBSOCKET = 'true';
   process.env.WEBSOCKET_PORT = '1234';
+  process.env.NEXT_PUBLIC_WEBSOCKET_URL = 'wss://ws.example.com:1234/ws/socket.io';
   const mockFetch = global.fetch as jest.Mock;
   mockFetch.mockResolvedValueOnce({
     ok: true,
@@ -155,6 +156,7 @@ test('GET /api/socket/status reports running when health check succeeds', async 
 
   const res = await socketStatusGet();
   const data = await res.json();
+  expect(mockFetch).toHaveBeenCalledWith('https://ws.example.com:1234/health');
   expect(res.status).toBe(200);
   expect(data.status).toBe('running');
   expect(data.clients).toBe(5);
@@ -163,11 +165,13 @@ test('GET /api/socket/status reports running when health check succeeds', async 
 test('GET /api/socket/status reports error when health check fails', async () => {
   process.env.ENABLE_WEBSOCKET = 'true';
   process.env.WEBSOCKET_PORT = '1234';
+  process.env.NEXT_PUBLIC_WEBSOCKET_URL = 'ws://ws.example.com:1234/ws/socket.io';
   const mockFetch = global.fetch as jest.Mock;
   mockFetch.mockRejectedValueOnce(new Error('connection refused'));
 
   const res = await socketStatusGet();
   const data = await res.json();
+  expect(mockFetch).toHaveBeenCalledWith('http://ws.example.com:1234/health');
   expect(res.status).toBe(200);
   expect(data.status).toBe('error');
   expect(data.message).toMatch(/connection refused/i);


### PR DESCRIPTION
## Summary
- derive health check host from `NEXT_PUBLIC_WEBSOCKET_URL`
- ensure status route falls back to localhost only when URL is unset
- verify the host used in socket status tests

## Testing
- `npx jest tests/api.test.ts --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_684e1659ed9c83228ec281aa9ac5f75f