### PR TITLE
Add configurable WhatsApp Web version URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,8 @@ PUPPETEER_EXECUTABLE_PATH=
 # Optional extra flags passed to Chromium, comma separated
 # Example: PUPPETEER_ARGS=--disable-crashpad
 PUPPETEER_ARGS=
+# Remote path to the WhatsApp Web version HTML
+WHATSAPP_WEB_VERSION_URL=https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/2.2412.54.html
 
 # Logging
 LOG_LEVEL=debug

--- a/README.md
+++ b/README.md
@@ -72,8 +72,7 @@ cp .env.example .env
 - `ADMIN_USERNAME` و`ADMIN_PASSWORD`: بيانات الدخول للوحة التحكم.
 - `JWT_SECRET`: مفتاح توقيع التوكنات.
 - `DATABASE_PATH`: مسار قاعدة البيانات.
-
-
+- `WHATSAPP_WEB_VERSION_URL`: مسار HTML لإصدار WhatsApp Web.
 - `CORS_ORIGIN`: قائمة بالمصادر المسموح بها مفصولة بفواصل **دون مسافات**.
 - `ENABLE_WEBSOCKET` و`WEBSOCKET_PORT`: تشغيل خادم WebSocket وتحديد المنفذ. يجب أن يكون هذا المنفذ متاحًا وغير مستخدم قبل التشغيل.
 - بقية المتغيرات موثقة داخل `.env.example` ويمكن تعديلها حسب الحاجة.

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -38,6 +38,9 @@ export const AUTO_CONNECT_DEVICES = process.env.AUTO_CONNECT_DEVICES === "true"
 export const WHATSAPP_SERVER_PORT = Number.parseInt(process.env.WHATSAPP_SERVER_PORT || "3002")
 export const PUPPETEER_EXECUTABLE_PATH = process.env.PUPPETEER_EXECUTABLE_PATH
 export const PUPPETEER_ARGS = process.env.PUPPETEER_ARGS
+export const WHATSAPP_WEB_VERSION_URL =
+  process.env.WHATSAPP_WEB_VERSION_URL ||
+  "https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/2.2412.54.html"
 
 // إعدادات السجلات
 export const LOG_LEVEL = process.env.LOG_LEVEL || "debug"

--- a/lib/whatsapp-client-manager.ts
+++ b/lib/whatsapp-client-manager.ts
@@ -11,6 +11,7 @@ import {
   PUPPETEER_ARGS,
   ENABLE_WEBSOCKET,
   AUTO_CONNECT_DEVICES,
+  WHATSAPP_WEB_VERSION_URL,
 } from "./config";
 
 // التأكد من وجود مجلد الجلسات
@@ -256,8 +257,7 @@ class WhatsAppClientManager extends EventEmitter {
         puppeteer: puppeteerOptions,
         webVersionCache: {
           type: "remote",
-          remotePath:
-            "https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/2.2412.54.html",
+          remotePath: WHATSAPP_WEB_VERSION_URL,
         },
       });
 


### PR DESCRIPTION
## Summary
- make WhatsApp web version remote path configurable
- expose `WHATSAPP_WEB_VERSION_URL` in env example
- document new variable in README

## Testing
- `npm test` *(fails: Cannot find module 'bcrypt_lib.node')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684e165e3fe08322b39a0a84d0b9384f