### PR TITLE
Include tsconfig.json in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /app
 
 # Copy package manifests first for better Docker layer caching
-COPY package.json package-lock.json .npmrc tsconfig.ws.json ./
+COPY package.json package-lock.json .npmrc tsconfig.ws.json tsconfig.json ./
 
 # Install dependencies with development packages enabled
 ENV NODE_ENV=development


### PR DESCRIPTION
## Summary
- copy `tsconfig.json` during Docker build so TypeScript can extend the base config

## Testing
- `npm test --silent` *(fails: Test Suites: 1 failed)*

------
https://chatgpt.com/codex/tasks/task_e_684e16e4cd148322ac3f5d46820cd751