### PR TITLE
Fix Docker manifest copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /app
 
 # Copy package manifests first for better Docker layer caching
-COPY package.json package-lock.json .npmrc tsconfig.ws.json ./
+COPY package.json package-lock.json .npmrc tsconfig.ws.json tsconfig.json ./
 
 # Install dependencies with development packages enabled
 ENV NODE_ENV=development


### PR DESCRIPTION
## Summary
- include `tsconfig.json` when copying package manifests

## Testing
- `npm ci`
- `docker-compose build` *(fails: Docker daemon not running)*

------
https://chatgpt.com/codex/tasks/task_e_684e1bfbef888322946c2ecc95870352