### PR TITLE
Ensure native deps compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ cd whatsapp-manager
 
 # تثبيت الاعتماديات (مع تخطي تنزيل المتصفح المدمج)
 PUPPETEER_SKIP_DOWNLOAD=1 npm install --ignore-scripts
+# في حال فشل تثبيت الحزم المدمجة، شغّل
+npm run rebuild:native
 
 # تشغيل الخادم في وضع التطوير
 npm run dev

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "build:ws": "tsc -p tsconfig.ws.json",
     "prews:prod": "npm run build:ws",
     "ws:prod": "node dist/websocket-server.js",
-    "prepare": "npm run build:ws"
+    "prepare": "npm run build:ws",
+    "rebuild:native": "npm rebuild bcrypt better-sqlite3 --build-from-source",
+    "postinstall": "npm run rebuild:native"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.11",


### PR DESCRIPTION
## Summary
- allow websocket and webserver to run by rebuilding native modules
- document rebuilding step for npm install

## Testing
- `npm run lint`
- `npm run build`
- `npm run build:ws`
- `npm run dev` *(then Ctrl+C)*
- `npm run ws` *(then Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_684e1eadb1008322b3d0cde3447ca4cb