### PR TITLE
Fix Docker build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY package.json package-lock.json .npmrc tsconfig.ws.json tsconfig.json ./
 ENV NODE_ENV=development
 # Use a temporary database during build to avoid SQLite locking errors
 ENV DATABASE_PATH=/tmp/whatsapp_manager_build.db
-RUN npm ci && npm cache clean --force
+RUN npm ci --ignore-scripts && npm cache clean --force
 
 # Copy the rest of the application source
 COPY . .


### PR DESCRIPTION
## Summary
- avoid running prepare script before source is copied

## Testing
- `npm install --ignore-scripts`
- `npm test --silent -- -w=1` *(fails: Your app (or one of its dependencies) is using an outdated JSX transform)*

------
https://chatgpt.com/codex/tasks/task_e_684e1e4a0bb08322a959eec24d51794a