### PR TITLE
Fix docker build for native modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ ENV NODE_ENV=development
 # Use a temporary database during build to avoid SQLite locking errors
 ENV DATABASE_PATH=/tmp/whatsapp_manager_build.db
 RUN npm ci --ignore-scripts && npm cache clean --force
+RUN npm run rebuild:native
 
 # Copy the rest of the application source
 COPY . .


### PR DESCRIPTION
## Summary
- rebuild native modules when building the Docker image

## Testing
- `npm install --ignore-scripts`
- `npm test` *(fails: Cannot find module `bcrypt_lib.node`)*
- `docker build -t whatsapp-manager:test .` *(fails: Cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_684e6ab0aa6083228238a049ade898db