### PR TITLE
Add dynamic credentials in CLI

### DIFF
--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -585,8 +585,8 @@ start_system() {
             echo -e "${BLUE}🌐 يمكنك الوصول للنظام عبر: http://localhost:3000${NC}"
         fi
         
-        echo -e "${YELLOW}👤 المستخدم: admin${NC}"
-        echo -e "${YELLOW}🔑 كلمة المرور: admin123${NC}"
+        echo -e "${YELLOW}👤 المستخدم: ${ADMIN_USERNAME}${NC}"
+        echo -e "${YELLOW}🔑 كلمة المرور: ${ADMIN_PASSWORD}${NC}"
     else
         echo -e "${RED}❌ فشل في تشغيل النظام${NC}"
         echo -e "${YELLOW}📋 عرض السجلات: wa-manager logs${NC}"
@@ -866,8 +866,13 @@ rebuild_env() {
     read -p "أدخل اسم الدومين (مثال: wa.example.com) [wa-api.developments.world]: " DOMAIN_NAME
     DOMAIN_NAME=${DOMAIN_NAME:-wa-api.developments.world}
     read -p "أدخل البريد الإلكتروني (لشهادة SSL) [info@wa-api.developments.world]: " EMAIL
+
     EMAIL=${EMAIL:-info@wa-api.developments.world}
 
+    read -p "أدخل اسم المستخدم للوحة التحكم [admin]: " ADMIN_USERNAME
+    ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
+    read -p "أدخل كلمة المرور للوحة التحكم [admin123]: " ADMIN_PASSWORD
+    ADMIN_PASSWORD=${ADMIN_PASSWORD:-admin123}
     cat > .env <<EOL
 # إعدادات الخادم
 PORT=3000
@@ -884,8 +889,8 @@ JWT_EXPIRES_IN=24h
 REFRESH_TOKEN_EXPIRES_IN=7d
 
 # بيانات الإدارة الافتراضية
-ADMIN_USERNAME=admin
-ADMIN_PASSWORD=admin123
+ADMIN_USERNAME=${ADMIN_USERNAME}
+ADMIN_PASSWORD=${ADMIN_PASSWORD}
 
 # إعدادات الأمان
 MAX_AUTH_ATTEMPTS=5


### PR DESCRIPTION
## Summary
- load admin credentials from `.env` after starting the system
- ask for admin credentials during `rebuild_env` and store them in the file

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e70d326a48322b5437eea01490697