### PR TITLE
Remove duplicate Tailwind base import

### DIFF
--- a/app/client-layout.tsx
+++ b/app/client-layout.tsx
@@ -8,7 +8,6 @@ import { I18nProvider } from "@/lib/i18n";
 import { useCurrentLocale } from "@/lib/use-locale";
 
 import "../styles/globals.css";
-import "../styles/themes/colors.css";
 
 export default function ClientLayout({
   children,

--- a/styles/themes/colors.css
+++ b/styles/themes/colors.css
@@ -1,4 +1,3 @@
-@tailwind base;
 
 /* Theme color variables injected by Tailwind plugin */
 @layer base {


### PR DESCRIPTION
## Summary
- drop theme color CSS import from client layout
- remove redundant `@tailwind base` from color theme CSS

## Testing
- `npm run lint`
- `npm test` *(fails: Could not locate the bindings file for better-sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_684e7a4c25a88322b39f73b413cec254