### PR TITLE
Fix env recreation when cleaning or uninstalling

### DIFF
--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -77,6 +77,21 @@ ensure_openssl() {
     fi
 }
 
+# التأكد من وجود ملف .env عند الحاجة
+ensure_env_file() {
+    if [ ! -f ".env" ]; then
+        if npm run --silent setup >/dev/null 2>&1; then
+            npm run --silent setup >/dev/null 2>&1
+        elif [ -f "scripts/generate-env.js" ]; then
+            node scripts/generate-env.js >/dev/null 2>&1
+        elif [ -f ".env.example" ]; then
+            cp .env.example .env
+        else
+            touch .env
+        fi
+    fi
+}
+
 # عرض المساعدة
 show_help() {
     echo -e "${BLUE}=== WhatsApp Manager CLI ===${NC}"
@@ -677,7 +692,10 @@ clean_system() {
     if [ -d "$DEFAULT_PATH" ]; then
         cd $DEFAULT_PATH
     fi
-    
+
+    # ضمان وجود ملف .env لتفادي رسائل الخطأ
+    ensure_env_file
+
     # تحديد ملف البيئة لاستخدامه مع Docker Compose لتفادي التحذيرات
     if [ -f ".env" ]; then
         $DOCKER_COMPOSE_CMD --env-file .env down
@@ -768,6 +786,9 @@ uninstall_system() {
     # التحقق من المسار
     if [ -d "$DEFAULT_PATH" ]; then
         cd $DEFAULT_PATH
+
+        # ضمان وجود ملف .env لتفادي رسائل الخطأ
+        ensure_env_file
 
         # إيقاف النظام مع مراعاة ملف البيئة في حال وجوده
         if [ -f ".env" ]; then


### PR DESCRIPTION
## Summary
- add `ensure_env_file` to create a temporary `.env` file when missing
- call `ensure_env_file` in `clean_system` and `uninstall_system`

## Testing
- `bash -n wa-manager.sh`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7d48d5f48322b95a46da90a2acab