### PR TITLE
Fix install command path

### DIFF
--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -532,7 +532,7 @@ install_system_command() {
     echo -e "${BLUE}📦 تثبيت الأمر في النظام...${NC}"
 
     # نسخ السكريبت إلى /usr/local/bin
-    cp $0 /usr/local/bin/wa-manager
+    cp "$SCRIPT_DIR/wa-manager.sh" /usr/local/bin/wa-manager
     chmod +x /usr/local/bin/wa-manager
 
     echo -e "${GREEN}✅ تم تثبيت الأمر بنجاح${NC}"


### PR DESCRIPTION
## Summary
- fix `install_system_command` to copy from script dir

## Testing
- `npm run lint`
- `npm test -- -i` *(fails: Cannot find module bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_684e89057c788322ba9be33aa6624f61