### PR TITLE
Add health endpoint to Nginx config

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -91,6 +91,15 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        location /health {
+            proxy_pass http://whatsapp_ws/health;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         # Static files caching
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
             expires 1y;


### PR DESCRIPTION
## Summary
- proxy /health requests to the websocket service

Remember to reload or restart Nginx after deploying this change.

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8a071620832284ba9af81d44ae65