### PR TITLE
Enable bash auto-completion for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,10 @@ wa-manager install pm2   # تثبيت Node.js وPM2 وتشغيل التطبيق 
 ```
 
 أثناء تشغيل `wa-manager install full` سيُطلب منك تحديد اسم المستخدم وكلمة المرور للمشرف، مع قيم افتراضية يمكن قبولها بالضغط على Enter.
-
+بعد تثبيت الأمر عبر `install cli` أو `install full` يتم إنشاء ملف إكمال تلقائي في `/etc/bash_completion.d/wa-manager`. يمكن تفعيله مباشرةً بدون إعادة تسجيل الخروج عبر الأمر:
+```bash
+source /etc/bash_completion.d/wa-manager
+```
 ### تشغيل التطبيق عبر PM2
 بعد تنفيذ أمر التثبيت يمكن إدارة الخدمة باستخدام PM2:
 ```bash

--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -506,6 +506,7 @@ EOL
     
     # تثبيت wa-manager في النظام
     install_system_command
+    install_autocomplete
 
     # تشغيل النظام
     cd $DEFAULT_PATH
@@ -539,9 +540,30 @@ install_system_command() {
     echo -e "${YELLOW}يمكنك الآن استخدام الأمر 'wa-manager' من أي مكان${NC}"
 }
 
+# تثبيت إكمال أوامر bash
+install_autocomplete() {
+    require_root
+    echo -e "${BLUE}⚙️ إعداد إكمال تلقائي للأوامر...${NC}"
+
+    cat >/etc/bash_completion.d/wa-manager <<'EOF'
+_wa_manager_completion() {
+    local cmds="help start stop restart status logs install uninstall clean monitor env update backup restore rebuild"
+    COMPREPLY=( $(compgen -W "${cmds}" -- "${COMP_WORDS[1]}") )
+}
+complete -F _wa_manager_completion wa-manager
+EOF
+
+    echo -e "${GREEN}✅ تم تثبيت الإكمال التلقائي${NC}"
+    # تفعيل الإكمال التلقائي مباشرة دون الحاجة لتسجيل خروج المستخدم
+    if [ -f /etc/bash_completion.d/wa-manager ]; then
+        source /etc/bash_completion.d/wa-manager
+    fi
+}
+
 # تثبيت CLI فقط
 install_cli() {
     install_system_command
+    install_autocomplete
 }
 
 # تشغيل النظام


### PR DESCRIPTION
## Summary
- add install_autocomplete helper in `wa-manager.sh`
- run auto-completion setup when installing CLI or full stack
- document the new auto-completion feature in README
- load the completion script immediately after installation

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e89020d688322b61af908687a3092