### PR TITLE
Update websocket health path logic

### DIFF
--- a/app/api/socket/status/route.ts
+++ b/app/api/socket/status/route.ts
@@ -17,7 +17,8 @@ export async function GET() {
       try {
         const parsed = new URL(process.env.NEXT_PUBLIC_WEBSOCKET_URL)
         const protocol = parsed.protocol.startsWith("wss") ? "https" : "http"
-        healthUrl = `${protocol}://${parsed.host}/health`
+        const basePath = parsed.pathname.replace(/\/socket\.io\/?$/, "")
+        healthUrl = `${protocol}://${parsed.host}${basePath}/health`
       } catch {
         healthUrl = `http://localhost:${websocketPort}/health`
       }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -172,7 +172,7 @@ test('GET /api/socket/status reports running when health check succeeds', async 
 
   const res = await socketStatusGet();
   const data = await res.json();
-  expect(mockFetch).toHaveBeenCalledWith('https://ws.example.com:1234/health');
+  expect(mockFetch).toHaveBeenCalledWith('https://ws.example.com:1234/ws/health');
   expect(res.status).toBe(200);
   expect(data.status).toBe('running');
   expect(data.clients).toBe(5);
@@ -187,7 +187,7 @@ test('GET /api/socket/status reports error when health check fails', async () =>
 
   const res = await socketStatusGet();
   const data = await res.json();
-  expect(mockFetch).toHaveBeenCalledWith('http://ws.example.com:1234/health');
+  expect(mockFetch).toHaveBeenCalledWith('http://ws.example.com:1234/ws/health');
   expect(res.status).toBe(200);
   expect(data.status).toBe('error');
   expect(data.message).toMatch(/connection refused/i);


### PR DESCRIPTION
## Summary
- parse NEXT_PUBLIC_WEBSOCKET_URL pathname to preserve base path
- adjust expected websocket health path in tests

## Testing
- `CI=true npx jest --runInBand --forceExit`

------
https://chatgpt.com/codex/tasks/task_e_684e8a0939b08322bd25944241e191e3