### PR TITLE
Install iproute2 in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get install -y \
     g++ \
     sqlite3 \
     curl \
+    iproute2 \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- include `iproute2` in system packages

## Testing
- `docker build -t whatsapp-manager-test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e957c6c70832298e55ef9903e61e1