### PR TITLE
Fix CSS syntax issue in base theme

### DIFF
--- a/styles/themes/base.css
+++ b/styles/themes/base.css
@@ -1,4 +1,3 @@
-
 /* Updated theme colors for a cleaner modern design */
 /* Refreshed global styles for better UX */
 
@@ -16,9 +15,20 @@ html {
 
 body {
   font-family:
-    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Cairo",
-    "Tajawal", sans-serif;
+    "Inter",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    "Roboto",
+    "Oxygen",
+    "Ubuntu",
+    "Cantarell",
+    "Fira Sans",
+    "Droid Sans",
+    "Helvetica Neue",
+    "Cairo",
+    "Tajawal",
+    sans-serif;
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -211,7 +221,6 @@ body {
       line-height: 1.25rem;
     }
   }
-}
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- fix unbalanced closing brace in `base.css`

## Testing
- `npm run lint`
- `npm test` *(fails: cannot find module `bcrypt_lib.node`)*

------
https://chatgpt.com/codex/tasks/task_e_684e95ba475c8322a565e941d26c0698