### PR TITLE
Update env defaults for Puppeteer

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ wa-manager install pm2   # تثبيت Node.js وPM2 وتشغيل التطبيق 
 ```bash
 source /etc/bash_completion.d/wa-manager
 ```
+> **ملاحظة:** يترك سكربت التثبيت القيم `PUPPETEER_EXECUTABLE_PATH` و`PUPPETEER_ARGS` فارغة ضمن ملف `.env`، ليتولى Puppeteer تنزيل متصفح Chromium تلقائيًا واستخدام الإعدادات الافتراضية.
+
 ### تشغيل التطبيق عبر PM2
 بعد تنفيذ أمر التثبيت يمكن إدارة الخدمة باستخدام PM2:
 ```bash

--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -304,6 +304,7 @@ ENABLE_WEBSOCKET=true
 WEBSOCKET_PORT=3001
 NEXT_PUBLIC_WEBSOCKET_URL=wss://${DOMAIN_NAME}/ws/socket.io
 
+# Leave blank to auto-download Chromium and use default flags
 PUPPETEER_EXECUTABLE_PATH=
 PUPPETEER_ARGS=
 
@@ -961,6 +962,7 @@ ENABLE_WEBSOCKET=true
 WEBSOCKET_PORT=3001
 NEXT_PUBLIC_WEBSOCKET_URL=wss://${DOMAIN_NAME}/ws/socket.io
 
+# Leave blank to auto-download Chromium and use default flags
 PUPPETEER_EXECUTABLE_PATH=
 PUPPETEER_ARGS=
 


### PR DESCRIPTION
## Summary
- add note about Puppeteer env vars in README
- document that install script sets `PUPPETEER_EXECUTABLE_PATH` and `PUPPETEER_ARGS` to empty
- add the same comment in `wa-manager.sh` for both `install_full` and `rebuild_env`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e982748088322af6e669b4a77817c