### PR TITLE
Fix PM2 build step

### DIFF
--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -218,7 +218,7 @@ install_pm2() {
     fi
 
     echo -e "${YELLOW}⏳ بناء التطبيق...${NC}"
-    if ! npm run build && npm run build:ws; then
+    if ! npm run build || ! npm run build:ws; then
         echo -e "${RED}❌ فشل عملية البناء${NC}"
         return 1
     fi


### PR DESCRIPTION
## Summary
- update build step in `install_pm2` to ensure both builds run

## Testing
- `npm test` *(fails: Cannot find module bcrypt)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684e9dc3acb083229a57104e422a3dcd