### PR TITLE
Fix build step in PM2 installer

### DIFF
--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -212,16 +212,17 @@ install_pm2() {
     fix_permissions
 
     echo -e "${YELLOW}⏳ تثبيت الاعتماديات...${NC}"
-    if ! npm ci --omit=dev; then
+    if ! npm ci; then
         echo -e "${RED}❌ فشل تثبيت الاعتماديات${NC}"
         return 1
     fi
 
     echo -e "${YELLOW}⏳ بناء التطبيق...${NC}"
-    if ! npm run build && npm run build:ws; then
+    if ! npm run build || ! npm run build:ws; then
         echo -e "${RED}❌ فشل عملية البناء${NC}"
         return 1
     fi
+    npm prune --omit=dev
 
     echo -e "${YELLOW}⏳ إنشاء ملف .env وقاعدة البيانات...${NC}"
     if ! npm run --silent setup; then


### PR DESCRIPTION
## Summary
- install dev dependencies in `install_pm2`
- run both build steps before pruning dev packages

## Testing
- `npm run build:ws`


------
https://chatgpt.com/codex/tasks/task_e_684e9dc2106c8322a0e1abd5165b6b1c