### PR TITLE
Update README test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,11 @@ npm run setup
 ```bash
 cp .env.test .env
 PUPPETEER_SKIP_DOWNLOAD=1 npm install --ignore-scripts
+npm run rebuild:native
 npm test
 ```
-قد تتطلب بعض الاختبارات توفر تبعيات إضافية حسب البيئة.
+قد تتطلب بعض الاختبارات توفر تبعيات إضافية حسب البيئة. ويجب إعادة بناء حزم
+`bcrypt` و`better-sqlite3` المستعملة في الاختبارات قبل تشغيلها.
 
 ## فحص الكود
 لتشغيل ESLint:


### PR DESCRIPTION
## Summary
- add `npm run rebuild:native` to the test guide in README
- explain that rebuilding is needed for `bcrypt` and `better-sqlite3`

## Testing
- `npm test` *(fails: Cannot find module 'bcrypt/lib/binding/...')*

------
https://chatgpt.com/codex/tasks/task_e_684ea0c78acc8322bdfdf33e33f38ed7