### PR TITLE
Update README native rebuild note

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cd whatsapp-manager
 
 # تثبيت الاعتماديات (مع تخطي تنزيل المتصفح المدمج)
 PUPPETEER_SKIP_DOWNLOAD=1 npm install --ignore-scripts
-# في حال فشل تثبيت الحزم المدمجة، شغّل
+# بعد الانتهاء **يجب** تشغيل الأمر التالي لتجميع `bcrypt` و`better-sqlite3`
 npm run rebuild:native
 
 # تشغيل الخادم في وضع التطوير


### PR DESCRIPTION
## Summary
- clarify that `npm run rebuild:native` is mandatory after the install step
- mention that this compiles `bcrypt` and `better-sqlite3`

## Testing
- `npm ci`
- `npx jest --runInBand --silent` *(fails: output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_684ea0cd387483228d34a8040cc57e2e