### PR TITLE
Add Puppeteer crashpad note

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ node dist/websocket-server.js
 npx puppeteer browsers install chrome
 ```
 أو تحديد المسار عبر المتغير `PUPPETEER_EXECUTABLE_PATH`. في حال تركه فارغًا سيقوم السكربت بتنزيل نسخة متوافقة تلقائيًا عند التشغيل.
+#### استكشاف أخطاء Puppeteer
+إذا فشل المتصفح في الإقلاع وظهرت الرسالة `chrome_crashpad_handler: --database is required` فيكفي ضبط `PUPPETEER_ARGS=--disable-crashpad` داخل ملف `.env` لحل المشكلة.
+
 
 ## Docker
 لإنشاء نسخة مهيأة للإنتاج:


### PR DESCRIPTION
## Summary
- add troubleshooting tip for puppeteer crashpad issue in README

## Testing
- `npm test` *(fails: Cannot find module bcrypt_lib.node)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684eb2cb46fc83228c0ffd9d8a90a416