### PR TITLE
Improve error handling in device connect

### DIFF
--- a/app/devices/page.tsx
+++ b/app/devices/page.tsx
@@ -146,12 +146,13 @@ export default function DevicesPage() {
   }
 
   const handleConnect = async (deviceId: number) => {
+    let data: any
     try {
       const res = await fetch(`/api/devices/${deviceId}/connect`, {
         method: "POST",
         credentials: "include",
       })
-      const data = await res.json()
+      data = await res.json()
       if (!res.ok || !data.success) {
         throw new Error(data.error || "فشل الاتصال بالجهاز")
       }
@@ -166,10 +167,14 @@ export default function DevicesPage() {
       )
     } catch (err) {
       logger.error("Error connecting device:", err as Error)
+      const errorMsg =
+        (err instanceof Error && err.message) ||
+        (data && data.error) ||
+        "فشل الاتصال بالجهاز"
       toast({
         variant: "destructive",
         title: "خطأ",
-        description: "فشل الاتصال بالجهاز",
+        description: errorMsg,
       })
     }
   }


### PR DESCRIPTION
## Summary
- show detailed error message when device connection fails

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb90843f883228fb1a2faf0855327