### PR TITLE
Use RouteHandlerContext in dynamic routes

### DIFF
--- a/app/api/contacts/[id]/route.ts
+++ b/app/api/contacts/[id]/route.ts
@@ -2,13 +2,14 @@ export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 import { type NextRequest, NextResponse } from "next/server"
+import type { RouteHandlerContext } from "next"
 import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
 import { ValidationSchemas } from "@/lib/validation"
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: RouteHandlerContext<{ id: string }>,
 ) {
   const { id } = params
   try {
@@ -52,7 +53,7 @@ export async function GET(
 
 export async function PUT(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: RouteHandlerContext<{ id: string }>,
 ) {
   const { id } = params
   try {
@@ -99,7 +100,7 @@ export async function PUT(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: RouteHandlerContext<{ id: string }>,
 ) {
   const { id } = params
   try {

--- a/app/api/devices/[id]/connect/route.ts
+++ b/app/api/devices/[id]/connect/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
+import type { RouteHandlerContext } from "next"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
@@ -9,7 +10,7 @@ export const dynamic = "force-dynamic"
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: RouteHandlerContext<{ id: string }>,
 ) {
   const { id } = params
   try {

--- a/app/api/devices/[id]/disconnect/route.ts
+++ b/app/api/devices/[id]/disconnect/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
+import type { RouteHandlerContext } from "next"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
@@ -9,7 +10,7 @@ export const dynamic = "force-dynamic"
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: RouteHandlerContext<{ id: string }>,
 ) {
   const { id } = params
   try {

--- a/app/api/devices/[id]/route.ts
+++ b/app/api/devices/[id]/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
+import type { RouteHandlerContext } from "next"
 import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
@@ -9,7 +10,7 @@ export const dynamic = "force-dynamic"
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: RouteHandlerContext<{ id: string }>,
 ) {
   const { id } = params
   try {
@@ -82,7 +83,7 @@ export async function GET(
 
 export async function PUT(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: RouteHandlerContext<{ id: string }>,
 ) {
   const { id } = params
   try {
@@ -158,7 +159,7 @@ export async function PUT(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: RouteHandlerContext<{ id: string }>,
 ) {
   const { id } = params
   try {

--- a/app/api/devices/[id]/schedule/route.ts
+++ b/app/api/devices/[id]/schedule/route.ts
@@ -2,6 +2,7 @@ export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 import { type NextRequest, NextResponse } from "next/server"
+import type { RouteHandlerContext } from "next"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
@@ -9,7 +10,7 @@ import { ValidationSchemas } from "@/lib/validation"
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: RouteHandlerContext<{ id: string }>,
 ) {
   const { id } = params
   try {

--- a/app/api/devices/[id]/send-bulk/route.ts
+++ b/app/api/devices/[id]/send-bulk/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
+import type { RouteHandlerContext } from "next"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
@@ -9,7 +10,7 @@ export const dynamic = "force-dynamic"
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: RouteHandlerContext<{ id: string }>,
 ) {
   const { id } = params
   try {

--- a/app/api/devices/[id]/send-contact/route.ts
+++ b/app/api/devices/[id]/send-contact/route.ts
@@ -2,6 +2,7 @@ export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 import { type NextRequest, NextResponse } from "next/server"
+import type { RouteHandlerContext } from "next"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
@@ -9,7 +10,7 @@ import { ValidationSchemas } from "@/lib/validation"
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: RouteHandlerContext<{ id: string }>,
 ) {
   const { id } = params
   try {

--- a/app/api/devices/[id]/send-location/route.ts
+++ b/app/api/devices/[id]/send-location/route.ts
@@ -2,6 +2,7 @@ export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 import { type NextRequest, NextResponse } from "next/server"
+import type { RouteHandlerContext } from "next"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
@@ -10,7 +11,7 @@ import { logger } from "@/lib/logger"
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: RouteHandlerContext<{ id: string }>,
 ) {
   const { id } = params
   try {

--- a/app/api/devices/[id]/send-media/route.ts
+++ b/app/api/devices/[id]/send-media/route.ts
@@ -2,6 +2,7 @@ export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 import { type NextRequest, NextResponse } from "next/server"
+import type { RouteHandlerContext } from "next"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
@@ -11,7 +12,7 @@ import path from "path"
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: RouteHandlerContext<{ id: string }>,
 ) {
   const { id } = params
   try {

--- a/app/api/devices/[id]/send/route.ts
+++ b/app/api/devices/[id]/send/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
+import type { RouteHandlerContext } from "next"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
 import { verifyAuth } from "@/lib/auth"
@@ -10,7 +11,7 @@ export const dynamic = "force-dynamic"
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: RouteHandlerContext<{ id: string }>,
 ) {
   const { id } = params
   try {

--- a/types/next.d.ts
+++ b/types/next.d.ts
@@ -1,0 +1,5 @@
+declare module 'next' {
+  export interface RouteHandlerContext<TParams extends Record<string, any> = {}> {
+    params: TParams
+  }
+}


### PR DESCRIPTION
## Summary
- use `RouteHandlerContext` for all dynamic route handlers under `app/api/**/*/[id]/**/route.ts`
- add local declaration for `RouteHandlerContext` type

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ebd6f5e888322b76de96b57977c04