### PR TITLE
Update Metadata import for Next.js 15

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type React from "react"
-import type { Metadata } from "next"
+import type { Metadata } from "next/types"
 import { Tajawal, Inter } from "next/font/google"
 import ClientLayout from "./client-layout"
 import { cookies } from "next/headers"


### PR DESCRIPTION
## Summary
- import `Metadata` from `next/types` instead of `next`

## Testing
- `npm run build` *(fails: Environment variable `JWT_SECRET` is required)*

------
https://chatgpt.com/codex/tasks/task_e_684ee99ecab083229bfaf03104b4ddcf