### PR TITLE
Improve wa-manager install auto config

### DIFF
--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -593,6 +593,12 @@ start_system() {
         systemctl start docker
     fi
 
+    # التأكد من وجود ملف .env وإنشاءه عند الحاجة
+    ensure_env_file
+    if [ -f "scripts/generate-env.js" ]; then
+        node scripts/generate-env.js >/dev/null 2>&1
+    fi
+
     # التحقق من وجود الملفات
     check_files || return 1
 


### PR DESCRIPTION
## Summary
- tweak `wa-manager.sh` so `wa-manager start` generates `.env` automatically
- run `scripts/generate-env.js` to set `JWT_SECRET`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684ef26c5ea08322a5381544daa850b1