### PR TITLE
Fix duplicate websocket config blocks

### DIFF
--- a/etc/nginx/sites-available/whatsapp-manager.conf
+++ b/etc/nginx/sites-available/whatsapp-manager.conf
@@ -66,7 +66,8 @@ server {
     }
 
     # WebSocket
-    location /ws/socket.io/ {
+    # Accept `/ws/socket.io` with or without a trailing slash
+    location ^~ /ws/socket.io {
         proxy_pass http://whatsapp-manager:3001/socket.io/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/nginx-ssl.conf
+++ b/nginx-ssl.conf
@@ -64,7 +64,8 @@ server {
     }
     
     # WebSocket proxy (preferred path)
-    location /ws/socket.io/ {
+    # Accept `/ws/socket.io` with or without a trailing slash
+    location ^~ /ws/socket.io {
         proxy_pass http://whatsapp-manager:3001/socket.io/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/nginx.conf
+++ b/nginx.conf
@@ -33,7 +33,8 @@ http {
         limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
 
         # WebSocket endpoint (preferred path)
-        location /ws/socket.io/ {
+        # Accept `/ws/socket.io` with or without a trailing slash
+        location ^~ /ws/socket.io {
             proxy_pass http://whatsapp_ws/socket.io/;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;

--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -404,7 +404,8 @@ http {
         }
         
         # WebSocket endpoint (preferred path)
-        location /ws/socket.io/ {
+        # Accept `/ws/socket.io` with or without a trailing slash
+        location ^~ /ws/socket.io {
             proxy_pass http://whatsapp-manager:3001/socket.io/;
             proxy_http_version 1.1;
             proxy_set_header Upgrade \$http_upgrade;


### PR DESCRIPTION
## Summary
- simplify websocket location blocks by using a single prefix

## Testing
- `npm install`
- `npm test` *(fails: Could not locate the bindings file for better-sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_684eee05670483228d296641d3609f1d