### PR TITLE
Improve invalid token handling

### DIFF
--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -9,14 +9,7 @@ export async function GET(request: NextRequest) {
   try {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: authResult.message || "غير مصرح",
-          timestamp: new Date().toISOString(),
-        },
-        { status: 401 },
-      )
+      return buildUnauthorizedResponse(authResult)
     }
 
     // Ensure the database is initialized before querying

--- a/app/api/contacts/[id]/route.ts
+++ b/app/api/contacts/[id]/route.ts
@@ -3,7 +3,7 @@ export const dynamic = "force-dynamic"
 
 import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 import { ValidationSchemas } from "@/lib/validation"
 
 export async function GET(
@@ -14,7 +14,7 @@ export async function GET(
   try {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      return NextResponse.json(authResult, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     // Ensure database is initialized
@@ -58,7 +58,7 @@ export async function PUT(
   try {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      return NextResponse.json(authResult, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     // Ensure database is initialized
@@ -105,7 +105,7 @@ export async function DELETE(
   try {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      return NextResponse.json(authResult, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     // Ensure database is initialized

--- a/app/api/contacts/route.ts
+++ b/app/api/contacts/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 import { ValidationSchemas } from "@/lib/validation"
 
 export const runtime = "nodejs"
@@ -10,7 +10,7 @@ export async function GET(request: NextRequest) {
   try {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      return NextResponse.json(authResult, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     // Ensure database is initialized
@@ -40,7 +40,7 @@ export async function POST(request: NextRequest) {
   try {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      return NextResponse.json(authResult, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     // Ensure database is initialized

--- a/app/api/devices/[id]/connect/route.ts
+++ b/app/api/devices/[id]/connect/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
@@ -19,7 +19,7 @@ export async function POST(
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
       logger.info("❌ Authentication failed:", authResult.message)
-      return NextResponse.json(authResult, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     const deviceId = Number.parseInt(id)

--- a/app/api/devices/[id]/disconnect/route.ts
+++ b/app/api/devices/[id]/disconnect/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
@@ -16,7 +16,7 @@ export async function POST(
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      return NextResponse.json(authResult, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     const deviceId = Number.parseInt(id)

--- a/app/api/devices/[id]/route.ts
+++ b/app/api/devices/[id]/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { logger } from "@/lib/logger"
 
@@ -16,7 +16,7 @@ export async function GET(
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      return NextResponse.json(authResult, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     const deviceId = Number.parseInt(id)
@@ -89,7 +89,7 @@ export async function PUT(
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      return NextResponse.json(authResult, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     const deviceId = Number.parseInt(id)
@@ -165,7 +165,7 @@ export async function DELETE(
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      return NextResponse.json(authResult, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     const deviceId = Number.parseInt(id)

--- a/app/api/devices/[id]/schedule/route.ts
+++ b/app/api/devices/[id]/schedule/route.ts
@@ -4,7 +4,7 @@ export const dynamic = "force-dynamic"
 import { type NextRequest, NextResponse } from "next/server"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 import { ValidationSchemas } from "@/lib/validation"
 
 export async function POST(
@@ -15,7 +15,7 @@ export async function POST(
   try {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      return NextResponse.json(authResult, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     const deviceId = Number.parseInt(id)

--- a/app/api/devices/[id]/send-bulk/route.ts
+++ b/app/api/devices/[id]/send-bulk/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
@@ -16,7 +16,7 @@ export async function POST(
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      return NextResponse.json(authResult, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     const deviceId = Number.parseInt(id)

--- a/app/api/devices/[id]/send-contact/route.ts
+++ b/app/api/devices/[id]/send-contact/route.ts
@@ -4,7 +4,7 @@ export const dynamic = "force-dynamic"
 import { type NextRequest, NextResponse } from "next/server"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 import { ValidationSchemas } from "@/lib/validation"
 
 export async function POST(
@@ -15,7 +15,7 @@ export async function POST(
   try {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      return NextResponse.json(authResult, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     const deviceId = Number.parseInt(id)

--- a/app/api/devices/[id]/send-location/route.ts
+++ b/app/api/devices/[id]/send-location/route.ts
@@ -4,7 +4,7 @@ export const dynamic = "force-dynamic"
 import { type NextRequest, NextResponse } from "next/server"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 import { ValidationSchemas } from "@/lib/validation"
 import { logger } from "@/lib/logger"
 
@@ -16,7 +16,7 @@ export async function POST(
   try {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      return NextResponse.json(authResult, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     const deviceId = Number.parseInt(id)

--- a/app/api/devices/[id]/send-media/route.ts
+++ b/app/api/devices/[id]/send-media/route.ts
@@ -4,7 +4,7 @@ export const dynamic = "force-dynamic"
 import { type NextRequest, NextResponse } from "next/server"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 import { ValidationSchemas } from "@/lib/validation"
 import fs from "fs/promises"
 import path from "path"
@@ -17,7 +17,7 @@ export async function POST(
   try {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      return NextResponse.json(authResult, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     const deviceId = Number.parseInt(id)

--- a/app/api/devices/[id]/send/route.ts
+++ b/app/api/devices/[id]/send/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { whatsappManager } from "@/lib/whatsapp-client-manager"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 import { ValidationSchemas } from "@/lib/validation"
 import { logger } from "@/lib/logger"
 
@@ -20,7 +20,7 @@ export async function POST(
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
       logger.info("❌ Authentication failed:", authResult.message)
-      return NextResponse.json(authResult, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     const deviceId = Number.parseInt(id)

--- a/app/api/devices/route.ts
+++ b/app/api/devices/route.ts
@@ -4,7 +4,7 @@ export const dynamic = "force-dynamic"
 import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
 import { logger } from "@/lib/logger"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 
 export async function GET(request: NextRequest) {
   try {
@@ -14,7 +14,7 @@ export async function GET(request: NextRequest) {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
       logger.warn("❌ Authentication failed:", authResult.message)
-      return NextResponse.json({ success: false, error: "غير مصرح" }, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     logger.info("✅ Authentication successful")
@@ -55,7 +55,7 @@ export async function POST(request: NextRequest) {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
       logger.warn("❌ Authentication failed:", authResult.message)
-      return NextResponse.json({ success: false, error: "غير مصرح" }, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     logger.info("✅ Authentication successful")

--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -4,7 +4,7 @@ export const dynamic = "force-dynamic"
 import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
 import { logger } from "@/lib/logger"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 
 export async function GET(request: NextRequest) {
   try {
@@ -14,7 +14,7 @@ export async function GET(request: NextRequest) {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
       logger.warn("❌ Authentication failed:", authResult.message)
-      return NextResponse.json({ success: false, error: "غير مصرح" }, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     logger.info("✅ Authentication successful")

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
@@ -41,14 +41,7 @@ export async function GET(request: NextRequest) {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
       logger.info("❌ Authentication failed:", authResult.message)
-      return NextResponse.json(
-        {
-          success: false,
-          error: authResult.message || "غير مصرح",
-          timestamp: new Date().toISOString(),
-        },
-        { status: 401 },
-      )
+      return buildUnauthorizedResponse(authResult)
     }
 
     logger.info("✅ Authentication successful")
@@ -89,14 +82,7 @@ export async function POST(request: NextRequest) {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
       logger.info("❌ Authentication failed:", authResult.message)
-      return NextResponse.json(
-        {
-          success: false,
-          error: authResult.message || "غير مصرح",
-          timestamp: new Date().toISOString(),
-        },
-        { status: 401 },
-      )
+      return buildUnauthorizedResponse(authResult)
     }
 
     logger.info("✅ Authentication successful")

--- a/app/api/settings/external-api-key/route.ts
+++ b/app/api/settings/external-api-key/route.ts
@@ -2,13 +2,13 @@ export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
 import { NextRequest, NextResponse } from "next/server"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 import { db } from "@/lib/database"
 
 export async function GET(request: NextRequest) {
   const auth = await verifyAuth(request)
   if (!auth.success) {
-    return NextResponse.json({ success: false, error: "غير مصرح" }, { status: 401 })
+    return buildUnauthorizedResponse(auth)
   }
   await db.ensureInitialized()
   const value = db.getSetting("external_api_key")
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const auth = await verifyAuth(request)
   if (!auth.success) {
-    return NextResponse.json({ success: false, error: "غير مصرح" }, { status: 401 })
+    return buildUnauthorizedResponse(auth)
   }
   const { value } = await request.json()
   if (!value || typeof value !== "string") {

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -4,7 +4,7 @@ export const dynamic = "force-dynamic"
 import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
 import { logger } from "@/lib/logger"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 
 export async function GET(request: NextRequest) {
   try {
@@ -14,7 +14,7 @@ export async function GET(request: NextRequest) {
     const authResult = await verifyAuth(request)
     if (!authResult.success || !authResult.user) {
       logger.warn("❌ Authentication failed:", authResult.message)
-      return NextResponse.json({ success: false, error: "غير مصرح" }, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     logger.info("✅ Authentication successful")

--- a/app/api/stats/system/route.ts
+++ b/app/api/stats/system/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 import os from "os"
 import fs from "fs"
 import { logger } from "@/lib/logger"
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
     // التحقق من المصادقة
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return buildUnauthorizedResponse(authResult)
     }
 
     // جمع معلومات النظام

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/database"
-import { verifyAuth } from "@/lib/auth"
+import { verifyAuth, buildUnauthorizedResponse } from "@/lib/auth"
 import { logger } from "@/lib/logger"
 
 export const runtime = "nodejs"
@@ -14,14 +14,7 @@ export async function GET(request: NextRequest) {
     const authResult = await verifyAuth(request)
     if (!authResult.success) {
       logger.info("❌ Authentication failed:", authResult.message)
-      return NextResponse.json(
-        {
-          success: false,
-          error: authResult.message || "غير مصرح",
-          timestamp: new Date().toISOString(),
-        },
-        { status: 401 },
-      )
+      return buildUnauthorizedResponse(authResult)
     }
 
     logger.info("✅ Authentication successful")

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -10,23 +10,26 @@ beforeEach(() => {
     const auth = await import('../lib/auth');
     const token = auth.createAuthToken({ id: 1, username: 'user' });
     const req: any = { cookies: { get: () => ({ value: token }) }, headers: new Headers() };
-    const res = await auth.verifyAuth(req);
-    expect(res.success).toBe(true);
-    expect(res.user).toEqual({ userId: 1, username: 'user', role: 'user' });
+  const res = await auth.verifyAuth(req);
+  expect(res.success).toBe(true);
+  expect(res.user).toEqual({ userId: 1, username: 'user', role: 'user' });
+  expect(res.clearCookie).toBe(false);
   });
 
   test('verifyAuth fails with invalid token', async () => {
     const auth = await import('../lib/auth');
     const req: any = { cookies: { get: () => ({ value: 'bad' }) }, headers: new Headers() };
-    const res = await auth.verifyAuth(req);
-    expect(res.success).toBe(false);
-    expect(res.message).toBe('Invalid token');
+  const res = await auth.verifyAuth(req);
+  expect(res.success).toBe(false);
+  expect(res.message).toBe('Invalid token');
+  expect(res.clearCookie).toBe(true);
   });
 
   test('verifyAuth fails when token missing', async () => {
     const auth = await import('../lib/auth');
     const req: any = { cookies: { get: () => undefined }, headers: new Headers() };
-    const res = await auth.verifyAuth(req);
-    expect(res.success).toBe(false);
-    expect(res.message).toBe('No token provided');
+  const res = await auth.verifyAuth(req);
+  expect(res.success).toBe(false);
+  expect(res.message).toBe('No token provided');
+  expect(res.clearCookie).toBe(false);
   });


### PR DESCRIPTION
## Summary
- add clearCookie flag to verifyAuth and helper to build unauthorized responses
- clear auth cookie on invalid token
- update API routes to use buildUnauthorizedResponse
- test updated invalid token behaviour

## Testing
- `npm install --ignore-scripts`
- `npm run rebuild:native`
- `npx jest --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_e_684efd4b6ee883228ec59dc5df65f96e