### PR TITLE
Remove .env from docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,9 +14,7 @@ data/
 *.db
 
 # Environment and SSL files
-#.env is now included so build-time variables like NEXT_PUBLIC_WEBSOCKET_URL
-# are respected when creating the Docker image. Other env files remain ignored.
-!.env
+.env
 .env.*
 !.env.example
 ssl/

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,14 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 
+# Build-time variables
+ARG NEXT_PUBLIC_WEBSOCKET_URL
+ARG NEXT_PUBLIC_DOMAIN_NAME
+ARG NEXT_PUBLIC_WHATSAPP_API_URL
+ENV NEXT_PUBLIC_WEBSOCKET_URL=${NEXT_PUBLIC_WEBSOCKET_URL}
+ENV NEXT_PUBLIC_DOMAIN_NAME=${NEXT_PUBLIC_DOMAIN_NAME}
+ENV NEXT_PUBLIC_WHATSAPP_API_URL=${NEXT_PUBLIC_WHATSAPP_API_URL}
+
 # Copy package manifests first for better Docker layer caching
 COPY package.json package-lock.json .npmrc tsconfig.ws.json tsconfig.json ./
 
@@ -63,9 +71,6 @@ COPY . .
 
 # Ensure helper scripts are executable
 RUN chmod +x start-production.sh scripts/generate-env.js
-
-# توليد ملف البيئة تلقائياً عند البناء
-RUN node scripts/generate-env.js
 
 # Use production mode when building the Next.js application
 ENV NODE_ENV=production

--- a/README.md
+++ b/README.md
@@ -77,7 +77,18 @@ npx puppeteer browsers install chrome
 sudo chown -R 1001:1001 data logs
 docker-compose up --build -d
 ```
-يُشغِّل هذا الأمر حاوية التطبيق مع Nginx ويتولى السكربت `start-production.sh` ضبط البيئة وبدء خادم WebSocket افتراضيًا. يمكن إيقاف البث الفوري بوضع `ENABLE_WEBSOCKET=false` في ملف البيئة.
+يُشغِّل هذا الأمر حاوية التطبيق مع Nginx ويتولى السكربت `start-production.sh` ضبط البيئة وبدء خادم WebSocket افتراضيًا.
+يمكن تمرير المتغيرات العامة مثل `NEXT_PUBLIC_WEBSOCKET_URL` أثناء البناء:
+```bash
+docker build \
+  --build-arg NEXT_PUBLIC_WEBSOCKET_URL=wss://example.com/ws/socket.io \
+  -t whatsapp-manager .
+```
+ويمكن توفير القيم الحساسة عند التشغيل دون الحاجة لملف `.env` داخل الصورة:
+```bash
+docker run -e ADMIN_USERNAME=admin -e ADMIN_PASSWORD=secret -e JWT_SECRET=mysecret whatsapp-manager
+```
+يمكن إيقاف البث الفوري بوضع `ENABLE_WEBSOCKET=false` في ملف البيئة.
 يجب التأكد من أن المنفذ المحدد في `WEBSOCKET_PORT` غير مشغول قبل التشغيل وإلا سيتوقف السكربت عن العمل.
 
 يجب التأكد من أن المنفذ المحدد في `WEBSOCKET_PORT` غير مشغول قبل التشغيل وإلا سيتوقف السكربت عن العمل برسالة "Port $WEBSOCKET_PORT already in use".


### PR DESCRIPTION
## Summary
- do not include `.env` in docker image
- pass environment variables at build time using ARG/ENV
- document how to build image with `--build-arg` or runtime env vars

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: network access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684f0b631dc48322975636ccca200e24