### PR TITLE
Add note on Puppeteer connection reset

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -61,6 +61,7 @@ Or specify `PUPPETEER_EXECUTABLE_PATH`. Leaving it empty will download a compati
 #### Puppeteer troubleshooting
 If the browser fails to start with `chrome_crashpad_handler: --database is required` set `PUPPETEER_ARGS=--disable-crashpad` in `.env`.
 
+If you see `recvmsg: Connection reset by peer (104)` when launching the browser it usually means a missing Chromium library. Ensure all dependencies listed in the Dockerfile are installed and rebuild the container. See the dependency section in the Dockerfile for reference.
 ## Docker
 To build a production ready image make sure the `data/` and `logs/` directories are writable by UID `1001` then run:
 ```bash

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ npx puppeteer browsers install chrome
 #### استكشاف أخطاء Puppeteer
 إذا فشل المتصفح في الإقلاع وظهرت الرسالة `chrome_crashpad_handler: --database is required` فيكفي ضبط `PUPPETEER_ARGS=--disable-crashpad` داخل ملف `.env` لحل المشكلة.
 
+إذا ظهرت الرسالة `recvmsg: Connection reset by peer (104)` عند بدء المتصفح فقد يكون السبب نقص إحدى مكتبات Chromium. تأكد من تثبيت جميع تبعيات Chromium كما هي مذكورة في قسم الاعتماديات داخل `Dockerfile` ثم أعد بناء الحاوية.
 
 ## Docker
 لإنشاء نسخة مهيأة للإنتاج:


### PR DESCRIPTION
## Summary
- document how to resolve `recvmsg: Connection reset by peer (104)`
- point users to Dockerfile dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0e03867083229dd57585892e4651