### PR TITLE
Fix puppeteer flags

### DIFF
--- a/lib/whatsapp-client-manager.ts
+++ b/lib/whatsapp-client-manager.ts
@@ -223,7 +223,7 @@ class WhatsAppClientManager extends EventEmitter {
 
       // تكوين عميل WhatsApp
       const puppeteerOptions: any = {
-        headless: true,
+        headless: "new",
         args: [
           "--no-sandbox",
           "--disable-setuid-sandbox",
@@ -253,7 +253,6 @@ class WhatsAppClientManager extends EventEmitter {
           "--disable-client-side-phishing-detection",
           "--disable-component-update",
           "--disable-domain-reliability",
-          "--disable-crash-reporter",
           "--disable-features=TranslateUI",
           "--disable-translate",
           "--user-agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",


### PR DESCRIPTION
## Summary
- update to use the new headless mode for puppeteer
- remove duplicate crash reporter flag

## Testing
- `npx tsc --noEmit` *(fails: jest/next not installed)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0e00dc1083229a188287e44c2651