### PR TITLE
Install chromium and update env defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,11 +43,10 @@ RESTART_POLICY=unless-stopped
 
 # WhatsApp
 WHATSAPP_SERVER_PORT=3002
-# Leave blank to download a bundled Chromium automatically
-PUPPETEER_EXECUTABLE_PATH=
+# Path to system Chromium installed in the Docker image
+PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 # Optional extra flags passed to Chromium, comma separated
-# Example: PUPPETEER_ARGS=--disable-crashpad
-PUPPETEER_ARGS=
+PUPPETEER_ARGS=--disable-crashpad
 # Remote path to the WhatsApp Web version HTML
 WHATSAPP_WEB_VERSION_URL=https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/2.2412.54.html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM node:20-slim
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
+    chromium \
+    chromium-browser \
+    libnss3-dev \
     wget \
     ca-certificates \
     fonts-liberation \

--- a/README.en.md
+++ b/README.en.md
@@ -59,7 +59,7 @@ npx puppeteer browsers install chrome
 ```
 Or specify `PUPPETEER_EXECUTABLE_PATH`. Leaving it empty will download a compatible version at runtime.
 #### Puppeteer troubleshooting
-If the browser fails to start with `chrome_crashpad_handler: --database is required` set `PUPPETEER_ARGS=--disable-crashpad` in `.env`.
+The Docker image installs Chromium and sets `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium` with `PUPPETEER_ARGS=--disable-crashpad` by default. If you run outside Docker and see `chrome_crashpad_handler: --database is required`, set the same flag manually in your `.env` file.
 
 ## Docker
 To build a production ready image make sure the `data/` and `logs/` directories are writable by UID `1001` then run:
@@ -112,7 +112,7 @@ During `wa-manager install full` you will be asked to set the admin username and
 ```bash
 source /etc/bash_completion.d/wa-manager
 ```
-> **Note:** the installer leaves `PUPPETEER_EXECUTABLE_PATH` and `PUPPETEER_ARGS` empty in `.env` so Puppeteer downloads Chromium automatically with default settings.
+> **Note:** the installer now sets `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium` and `PUPPETEER_ARGS=--disable-crashpad` in `.env` so the preinstalled Chromium is used by default.
 
 ### Running via PM2
 After installation manage the service with PM2. Again ensure `data/` and `logs/` are writable by UID `1001`:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ npx puppeteer browsers install chrome
 ```
 أو تحديد المسار عبر المتغير `PUPPETEER_EXECUTABLE_PATH`. في حال تركه فارغًا سيقوم السكربت بتنزيل نسخة متوافقة تلقائيًا عند التشغيل.
 #### استكشاف أخطاء Puppeteer
-إذا فشل المتصفح في الإقلاع وظهرت الرسالة `chrome_crashpad_handler: --database is required` فيكفي ضبط `PUPPETEER_ARGS=--disable-crashpad` داخل ملف `.env` لحل المشكلة.
+تتضمن صورة Docker المتصفح Chromium وتضبط افتراضيًا `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium` مع `PUPPETEER_ARGS=--disable-crashpad`. عند تشغيل التطبيق خارج Docker وظهور الخطأ `chrome_crashpad_handler: --database is required` يكفي إضافة نفس العلم يدويًا في ملف `.env`.
 
 
 ## Docker
@@ -127,7 +127,7 @@ wa-manager install pm2   # تثبيت Node.js وPM2 وتشغيل التطبيق 
 ```bash
 source /etc/bash_completion.d/wa-manager
 ```
-> **ملاحظة:** يترك سكربت التثبيت القيم `PUPPETEER_EXECUTABLE_PATH` و`PUPPETEER_ARGS` فارغة ضمن ملف `.env`، ليتولى Puppeteer تنزيل متصفح Chromium تلقائيًا واستخدام الإعدادات الافتراضية.
+> **ملاحظة:** يقوم سكربت التثبيت الآن بضبط `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium` و`PUPPETEER_ARGS=--disable-crashpad` داخل ملف `.env` لاستخدام Chromium المثبت مسبقًا بشكل افتراضي.
 
 ### تشغيل التطبيق عبر PM2
 بعد تنفيذ أمر التثبيت يمكن إدارة الخدمة باستخدام PM2:


### PR DESCRIPTION
## Summary
- install `chromium`, `chromium-browser`, and `libnss3-dev` in Dockerfile
- set `PUPPETEER_EXECUTABLE_PATH` and `PUPPETEER_ARGS` in `.env.example`
- document the new defaults in both README files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f0bdfb1488322a61b118a03f06350