### PR TITLE
Remove chromium-browser from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM node:20-slim
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     chromium \
-    chromium-browser \
     libnss3-dev \
     wget \
     ca-certificates \


### PR DESCRIPTION
## Summary
- remove `chromium-browser` package from Dockerfile install list

## Testing
- `npm ci`
- `npm test`
- `docker build` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_684f103cb4608322ad2735f676dcbb8a