### PR TITLE
Fix build failure by generating .env in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,9 @@ COPY . .
 # Ensure helper scripts are executable
 RUN chmod +x start-production.sh scripts/generate-env.js
 
+# Ensure required environment variables exist before building
+RUN node scripts/generate-env.js
+
 # Use production mode when building the Next.js application
 ENV NODE_ENV=production
 RUN npm run build


### PR DESCRIPTION
## Summary
- ensure `.env` exists during Docker builds

## Testing
- `npx jest --runInBand --ci --silent`

------
https://chatgpt.com/codex/tasks/task_e_684f129d64508322a98eda86513d38ba