### PR TITLE
Include default Puppeteer crashpad flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,7 @@ WHATSAPP_SERVER_PORT=3002
 # Path to system Chromium installed in the Docker image
 PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 # Optional extra flags passed to Chromium, comma separated
+# Disable crashpad when using the bundled browser
 PUPPETEER_ARGS=--disable-crashpad
 # Remote path to the WhatsApp Web version HTML
 WHATSAPP_WEB_VERSION_URL=https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/2.2412.54.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,9 @@ RUN npm run build:ws
 
 # Use the real database location at runtime
 ENV DATABASE_PATH=/app/data/whatsapp_manager.db
+# Use the Chromium binary installed in the image with crashpad disabled
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+ENV PUPPETEER_ARGS=--disable-crashpad
 
 # Remove development dependencies after the build to keep the image slim
 RUN npm prune --production && npm cache clean --force

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
 #      Replace default credentials before using in production
       - NODE_ENV=production
       - DATABASE_PATH=/app/data/whatsapp_manager.db
+      - PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+      - PUPPETEER_ARGS=--disable-crashpad
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs

--- a/wa-manager.sh
+++ b/wa-manager.sh
@@ -350,9 +350,10 @@ ENABLE_WEBSOCKET=true
 WEBSOCKET_PORT=3001
 NEXT_PUBLIC_WEBSOCKET_URL=wss://${DOMAIN_NAME}/ws/socket.io
 
-# Leave blank to auto-download Chromium and use default flags
-PUPPETEER_EXECUTABLE_PATH=
-PUPPETEER_ARGS=
+# Use the system Chromium installed in the Docker image
+PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+# Disable crashpad to avoid browser launch errors
+PUPPETEER_ARGS=--disable-crashpad
 
 # إعدادات CORS
 CORS_ORIGIN=https://${DOMAIN_NAME}
@@ -1015,9 +1016,10 @@ ENABLE_WEBSOCKET=true
 WEBSOCKET_PORT=3001
 NEXT_PUBLIC_WEBSOCKET_URL=wss://${DOMAIN_NAME}/ws/socket.io
 
-# Leave blank to auto-download Chromium and use default flags
-PUPPETEER_EXECUTABLE_PATH=
-PUPPETEER_ARGS=
+# Use the system Chromium installed in the Docker image
+PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+# Disable crashpad to avoid browser launch errors
+PUPPETEER_ARGS=--disable-crashpad
 
 # إعدادات CORS
 CORS_ORIGIN=https://${DOMAIN_NAME}


### PR DESCRIPTION
## Summary
- add default `PUPPETEER_ARGS` and executable to Docker image
- expose those env vars in docker-compose
- set same defaults in installer script
- document flag in `.env.example`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f17536d288322997d6f2e287117ef