### PR TITLE
Fix Chrome crashpad handler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,9 +43,9 @@ RESTART_POLICY=unless-stopped
 
 # WhatsApp
 WHATSAPP_SERVER_PORT=3002
-# Path to system Chromium installed in the Docker image
-PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
-# Optional extra flags passed to Chromium, comma separated
+# Path to system Chrome installed in the Docker image
+PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
+# Optional extra flags passed to Chrome, comma separated
 PUPPETEER_ARGS=--disable-crashpad
 # Remote path to the WhatsApp Web version HTML
 WHATSAPP_WEB_VERSION_URL=https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/2.2412.54.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,14 @@ FROM node:20-slim
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
-    chromium \
-    libnss3-dev \
     wget \
-    ca-certificates \
+    curl \
+    gnupg \
+    ca-certificates && \
+    wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list' && \
+    apt-get update && apt-get install -y \
+    google-chrome-stable \
     fonts-liberation \
     libappindicator3-1 \
     libasound2 \
@@ -42,10 +46,12 @@ RUN apt-get update && apt-get install -y \
     make \
     g++ \
     sqlite3 \
-    curl \
     iproute2 \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
+
+# Prevent Puppeteer from downloading Chromium during install
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 
 WORKDIR /app

--- a/README.en.md
+++ b/README.en.md
@@ -59,9 +59,9 @@ npx puppeteer browsers install chrome
 ```
 Or specify `PUPPETEER_EXECUTABLE_PATH`. Leaving it empty will download a compatible version at runtime.
 #### Puppeteer troubleshooting
-The Docker image installs Chromium and sets `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium` with `PUPPETEER_ARGS=--disable-crashpad` by default. If you run outside Docker and see `chrome_crashpad_handler: --database is required`, set the same flag manually in your `.env` file.
+The Docker image installs Google Chrome and sets `PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable` with `PUPPETEER_ARGS=--disable-crashpad` by default. If you run outside Docker and see `chrome_crashpad_handler: --database is required`, set the same flag manually in your `.env` file.
 
-If you see `recvmsg: Connection reset by peer (104)` when launching the browser it usually means a missing Chromium library. Ensure all dependencies listed in the Dockerfile are installed and rebuild the container. See the dependency section in the Dockerfile for reference.
+If you see `recvmsg: Connection reset by peer (104)` when launching the browser it usually means a missing Chrome library. Ensure all dependencies listed in the Dockerfile are installed and rebuild the container. See the dependency section in the Dockerfile for reference.
 ## Docker
 To build a production ready image make sure the `data/` and `logs/` directories are writable by UID `1001` then run:
 ```bash
@@ -113,7 +113,7 @@ During `wa-manager install full` you will be asked to set the admin username and
 ```bash
 source /etc/bash_completion.d/wa-manager
 ```
-> **Note:** the installer now sets `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium` and `PUPPETEER_ARGS=--disable-crashpad` in `.env` so the preinstalled Chromium is used by default.
+> **Note:** the installer now sets `PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable` and `PUPPETEER_ARGS=--disable-crashpad` in `.env` so the preinstalled Chrome is used by default.
 
 ### Running via PM2
 After installation manage the service with PM2. Again ensure `data/` and `logs/` are writable by UID `1001`:

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ npx puppeteer browsers install chrome
 ```
 أو تحديد المسار عبر المتغير `PUPPETEER_EXECUTABLE_PATH`. في حال تركه فارغًا سيقوم السكربت بتنزيل نسخة متوافقة تلقائيًا عند التشغيل.
 #### استكشاف أخطاء Puppeteer
-تتضمن صورة Docker المتصفح Chromium وتضبط افتراضيًا `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium` مع `PUPPETEER_ARGS=--disable-crashpad`. عند تشغيل التطبيق خارج Docker وظهور الخطأ `chrome_crashpad_handler: --database is required` يكفي إضافة نفس العلم يدويًا في ملف `.env`.
+تتضمن صورة Docker المتصفح Google Chrome وتضبط افتراضيًا `PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable` مع `PUPPETEER_ARGS=--disable-crashpad`. عند تشغيل التطبيق خارج Docker وظهور الخطأ `chrome_crashpad_handler: --database is required` يكفي إضافة نفس العلم يدويًا في ملف `.env`.
 
-إذا ظهرت الرسالة `recvmsg: Connection reset by peer (104)` عند بدء المتصفح فقد يكون السبب نقص إحدى مكتبات Chromium. تأكد من تثبيت جميع تبعيات Chromium كما هي مذكورة في قسم الاعتماديات داخل `Dockerfile` ثم أعد بناء الحاوية.
+إذا ظهرت الرسالة `recvmsg: Connection reset by peer (104)` عند بدء المتصفح فقد يكون السبب نقص إحدى مكتبات Chrome. تأكد من تثبيت جميع تبعيات Chrome كما هي مذكورة في قسم الاعتماديات داخل `Dockerfile` ثم أعد بناء الحاوية.
 
 ## Docker
 لإنشاء نسخة مهيأة للإنتاج:
@@ -139,7 +139,7 @@ wa-manager install pm2   # تثبيت Node.js وPM2 وتشغيل التطبيق 
 ```bash
 source /etc/bash_completion.d/wa-manager
 ```
-> **ملاحظة:** يقوم سكربت التثبيت الآن بضبط `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium` و`PUPPETEER_ARGS=--disable-crashpad` داخل ملف `.env` لاستخدام Chromium المثبت مسبقًا بشكل افتراضي.
+> **ملاحظة:** يقوم سكربت التثبيت الآن بضبط `PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable` و`PUPPETEER_ARGS=--disable-crashpad` داخل ملف `.env` لاستخدام Chrome المثبت مسبقًا بشكل افتراضي.
 
 ### تشغيل التطبيق عبر PM2
 بعد تنفيذ أمر التثبيت يمكن إدارة الخدمة باستخدام PM2:

--- a/lib/whatsapp-client-manager.ts
+++ b/lib/whatsapp-client-manager.ts
@@ -268,6 +268,8 @@ class WhatsAppClientManager extends EventEmitter {
 
       if (PUPPETEER_EXECUTABLE_PATH) {
         puppeteerOptions.executablePath = PUPPETEER_EXECUTABLE_PATH;
+      } else {
+        puppeteerOptions.executablePath = "/usr/bin/google-chrome-stable";
       }
 
       const client = new Client({


### PR DESCRIPTION
## Summary
- install Google Chrome in Dockerfile
- prevent Puppeteer from downloading its own Chromium
- update Puppeteer executable defaults
- document Chrome usage in README files
- set default Chrome path in `.env.example` and the client manager

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f18090a948322a64a460c71e9d1ce