### PR TITLE
Remove metro4 css import

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,7 +40,7 @@ export default async function RootLayout({
   const dir = locale === "ar" ? "rtl" : "ltr"
   return (
     <html lang={locale} dir={dir}>
-      <body className={`${tajawal.className} ${inter.className} metro`}> 
+      <body className={`${tajawal.className} ${inter.className}`}> 
         <ClientLayout>{children}</ClientLayout>
       </body>
     </html>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,7 +1,5 @@
 @import "./themes/colors.css";
 @import "./themes/base.css";
-@import "metro4/build/css/metro.min.css";
-@import "metro4/build/css/metro-colors.min.css";
 
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
## Summary
- remove metro4 imports from global styles
- drop `metro` class from layout
- ensure newline at end of globals.css

## Testing
- `npx jest --runInBand --ci`

------
https://chatgpt.com/codex/tasks/task_e_684f24123530832294e037ce52f3ef72