### PR TITLE
Fix sidebar type error

### DIFF
--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { usePathname, useSearchParams } from "next/navigation"
 import { cn } from "@/lib/utils"
 import { Button, Badge, Separator } from "@/components/ui"
+import type { LucideIcon } from "lucide-react"
 import {
   LayoutDashboard,
   Smartphone,
@@ -26,7 +27,16 @@ interface SidebarProps {
   onClose?: () => void
 }
 
-const navigation = [
+interface NavigationItem {
+  name: string
+  href: string
+  icon: LucideIcon
+  badge: string | null
+  description: string
+  disabled?: boolean
+}
+
+const navigation: NavigationItem[] = [
   {
     name: "لوحة التحكم",
     href: "/dashboard",


### PR DESCRIPTION
## Summary
- define a `NavigationItem` interface with optional `disabled` flag
- use the new type for the sidebar navigation

## Testing
- `npm run lint`
- `npm test` *(fails: Could not locate the bindings file for better-sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_684f28a69dfc832290265267931ed904